### PR TITLE
fix issue where randomizer menu would be uninteractable

### DIFF
--- a/libultraship/libultraship/SohImGuiImpl.cpp
+++ b/libultraship/libultraship/SohImGuiImpl.cpp
@@ -703,7 +703,7 @@ namespace SohImGui {
         const std::shared_ptr<Window> wnd = GlobalCtx2::GetInstance()->GetWindow();
         ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoBackground |
             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoResize;
+            ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoResize;
         if (CVar_GetS32("gOpenMenuBar", 0)) window_flags |= ImGuiWindowFlags_MenuBar;
 
         const ImGuiViewport* viewport = ImGui::GetMainViewport();


### PR DESCRIPTION
after generating a seed

not sure what exactly is causing this, and this seems like a band-aid fix (i'm not sure why exactly this was changed in develop, maybe it's switch port related?)

merging this now anyways so it doesn't block development/testing.