### PR TITLE
respect ganon's boss key setting and treat castle/tower as one

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1206,6 +1206,7 @@ std::unordered_map<std::string, RandomizerSettingKey> SpoilerfileSettingNameToEn
     { "Start With Kokiri Sword", RSK_STARTING_KOKIRI_SWORD },
     { "Start With Ocarina", RSK_STARTING_OCARINA },
     { "Shuffle Dungeon Items:Maps/Compasses", RSK_STARTING_MAPS_COMPASSES },
+    { "Shuffle Dungeon Items:Ganon's Boss Key", RSK_GANONS_BOSS_KEY },
     { "Misc Settings:Gossip Stone Hints", RSK_GOSSIP_STONE_HINTS },
     { "Misc Settings:  Hint Clarity", RSK_HINT_CLARITY},
     { "Misc Settings:  Hint Distribution", RSK_HINT_DISTRIBUTION},

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -1661,9 +1661,27 @@ u8 Item_Give(GlobalContext* globalCtx, u8 item) {
         gSaveContext.inventory.equipment |= (gBitFlags[item - ITEM_BOOTS_KOKIRI] << gEquipShifts[EQUIP_BOOTS]);
         return ITEM_NONE;
     } else if ((item == ITEM_KEY_BOSS) || (item == ITEM_COMPASS) || (item == ITEM_DUNGEON_MAP)) {
-        gSaveContext.inventory.dungeonItems[gSaveContext.mapIndex] |= gBitFlags[item - ITEM_KEY_BOSS];
+        // if we get a boss/big key in ganon's castle (which doesn't have a map/compass)
+        // when rando'd it's for ganon's tower
+        if (gSaveContext.n64ddFlag && gSaveContext.mapIndex == 13) {
+            gSaveContext.inventory.dungeonItems[10] |= 1;
+        } else {
+            gSaveContext.inventory.dungeonItems[gSaveContext.mapIndex] |= gBitFlags[item - ITEM_KEY_BOSS];
+        }
         return ITEM_NONE;
     } else if (item == ITEM_KEY_SMALL) {
+        // if we get a small key in ganon's tower (boss key chest)
+        // when rando'd it's for ganon's castle
+        if (gSaveContext.n64ddFlag && gSaveContext.mapIndex == 10) {
+            if (gSaveContext.inventory.dungeonKeys[13] < 0) {
+                gSaveContext.inventory.dungeonKeys[13] = 1;
+                return ITEM_NONE;
+            } else {
+                gSaveContext.inventory.dungeonKeys[13]++;
+                return ITEM_NONE;
+            }
+        }
+
         if (gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex] < 0) {
             gSaveContext.inventory.dungeonKeys[gSaveContext.mapIndex] = 1;
             return ITEM_NONE;


### PR DESCRIPTION
* we were always starting with ganon's tower boss key, now the settings are actually respected
* small keys in ganon's tower are treated as ganon's castle keys
* big keys in ganon's castle are treated as ganon's tower keys 