### PR TITLE
fix lacs check

### DIFF
--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -234,10 +234,10 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
 
     if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT) && CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW) && LINK_IS_ADULT &&
         (gEntranceTable[((void)0, gSaveContext.entranceIndex)].scene == SCENE_TOKINOMA) &&
-        !Flags_GetEventChkInf(0xC4) && player != NULL && !Player_InBlockingCsMode(globalCtx, player)) {
+        !Flags_GetTreasure(globalCtx, 0x1E) && player != NULL && !Player_InBlockingCsMode(globalCtx, player)) {
         GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ARROW_LIGHT);
         GiveItemWithoutActor(globalCtx, getItemId);
-        Flags_SetEventChkInf(0xC4);
+        Flags_SetTreasure(globalCtx, 0x1E);
     }
 }
 


### PR DESCRIPTION
use a treasure check because we're setting the eventcheckinf flag to skip cutscenes