### PR TITLE
Fixes a Windows specific bottle-duping bug.

### DIFF
--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1918,6 +1918,7 @@ GetItemID Randomizer::GetItemFromActor(s16 actorId, s16 actorParams, s16 sceneNu
     return GetItemFromGet(this->itemLocations[GetCheckFromActor(sceneNum, actorId, actorParams)], ogItemId);
 }
 
+#pragma optimize("", off)
 bool Randomizer::GettingItemInBottle() {
     if (this->gettingBottledItem) {
         this->gettingBottledItem = false;
@@ -1925,6 +1926,7 @@ bool Randomizer::GettingItemInBottle() {
     }
     return false;
 }
+#pragma optimize("", on)
 
 GetItemID Randomizer::GetItemFromGet(RandomizerGet randoGet, GetItemID ogItemId) {
     // RANDOTODO find a more robust way to handle resetting this,


### PR DESCRIPTION
Compiler Optimizations on Windows were causing GettingItemInBottle to always return true, rather than checking the gettingBottledItem variable each time it was called. As a result, if you catch a Poe, it would give you a new bottle instead of putting a Poe in your existing bottle. The fix for now was simply turning optimization off for that function.