### PR TITLE
Restore owl shortcuts

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -136,7 +136,9 @@ void EnOwl_Init(Actor* thisx, GlobalContext* globalCtx) {
     // "conversation owl %4x no = %d, sv = %d"
     osSyncPrintf(VT_FGCOL(CYAN) " 会話フクロウ %4x no = %d, sv = %d\n" VT_RST, this->actor.params, owlType, switchFlag);
 
-    if (((owlType != OWL_DEFAULT) && (switchFlag < 0x20) && Flags_GetSwitch(globalCtx, switchFlag)) || gSaveContext.n64ddFlag) {
+    if (((owlType != OWL_DEFAULT) && (switchFlag < 0x20) && Flags_GetSwitch(globalCtx, switchFlag)) ||
+        // Owl shortcuts at SPOT06: Lake Hylia and SPOT16: Death Mountain Trail
+        (gSaveContext.n64ddFlag && !(globalCtx->sceneNum != SCENE_SPOT06 || globalCtx->sceneNum != SCENE_SPOT16))) {
         osSyncPrintf("savebitでフクロウ退避\n"); // "Save owl with savebit"
         Actor_Kill(&this->actor);
         return;
@@ -628,7 +630,7 @@ void func_80ACB274(EnOwl* this, GlobalContext* globalCtx) {
 void EnOwl_WaitDeathMountainShortcut(EnOwl* this, GlobalContext* globalCtx) {
     EnOwl_LookAtLink(this, globalCtx);
 
-    if (!gSaveContext.magicAcquired) {
+    if (!gSaveContext.magicAcquired && !gSaveContext.n64ddFlag) {
         if (func_80ACA558(this, globalCtx, 0x3062)) {
             Audio_PlayFanfare(NA_BGM_OWL);
             this->actionFunc = func_80ACB274;

--- a/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/soh/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -138,7 +138,7 @@ void EnOwl_Init(Actor* thisx, GlobalContext* globalCtx) {
 
     if (((owlType != OWL_DEFAULT) && (switchFlag < 0x20) && Flags_GetSwitch(globalCtx, switchFlag)) ||
         // Owl shortcuts at SPOT06: Lake Hylia and SPOT16: Death Mountain Trail
-        (gSaveContext.n64ddFlag && !(globalCtx->sceneNum != SCENE_SPOT06 || globalCtx->sceneNum != SCENE_SPOT16))) {
+        (gSaveContext.n64ddFlag && !(globalCtx->sceneNum == SCENE_SPOT06 || globalCtx->sceneNum == SCENE_SPOT16))) {
         osSyncPrintf("savebitでフクロウ退避\n"); // "Save owl with savebit"
         Actor_Kill(&this->actor);
         return;


### PR DESCRIPTION
Prevents killing the owl at Death Mountain Trail and Lake Hylia since in both cases he doesn't nag and provides shortcuts.

For the Death Mountain Trail shortcut, also skip the `magicAcquired` check so that the shortcut is always available.