### PR TITLE
name entry dropped spoiler logic

### DIFF
--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_nameset_PAL.c
@@ -464,6 +464,7 @@ void FileChoose_DrawNameEntry(GameState* thisx) {
                             gSaveContext.dayTime = dayTime;
                             this->configMode = CM_NAME_ENTRY_TO_MAIN;
                             CVar_SetS32("gOnFileSelectNameEntry", 0);
+                            CVar_SetS32("gNewFileDropped", 0);
                             this->nameBoxAlpha[this->buttonIndex] = this->nameAlpha[this->buttonIndex] = 200;
                             this->connectorAlpha[this->buttonIndex] = 255;
                             func_800AA000(300.0f, 0xB4, 0x14, 0x64);


### PR DESCRIPTION
when dropping a spoilerfile on name entry, it doesn't actually get loaded in time for the save init

this was not clear before, as the file select screen would have updated icons, but the new save wouldn't match

this makes it so the drop is ignored if the new save file is created, but still is loaded if the user backs out to the file select screen