### PR TITLE
Forest Temple Ganondrof cutscene skip

### DIFF
--- a/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -949,6 +949,7 @@ void BossGanondrof_SetupDeath(BossGanondrof* this, GlobalContext* globalCtx) {
     this->actionFunc = BossGanondrof_Death;
     Audio_QueueSeqCmd(0x1 << 28 | SEQ_PLAYER_BGM_MAIN << 24 | 0x100FF);
     Audio_PlayActorSound2(&this->actor, NA_SE_EN_FANTOM_DEAD);
+
     this->deathState = DEATH_START;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->work[GND_VARIANCE_TIMER] = 0;
@@ -981,7 +982,6 @@ void BossGanondrof_Death(BossGanondrof* this, GlobalContext* globalCtx) {
             osSyncPrintf("7\n");
             Gameplay_ChangeCameraStatus(globalCtx, this->deathCamera, CAM_STAT_ACTIVE);
             osSyncPrintf("8\n");
-            this->deathState = DEATH_THROES;
             player->actor.speedXZ = 0.0f;
             this->timers[0] = 50;
             this->cameraEye = camera->eye;
@@ -1008,11 +1008,26 @@ void BossGanondrof_Death(BossGanondrof* this, GlobalContext* globalCtx) {
         case DEATH_THROES:
             switch (this->work[GND_ACTION_STATE]) {
                 case DEATH_SPASM:
-                    if (Animation_OnFrame(&this->skelAnime, this->fwork[GND_END_FRAME])) {
+                    if (Animation_OnFrame(&this->skelAnime, this->fwork[GND_END_FRAME]) && !gSaveContext.n64ddFlag) {
                         this->fwork[GND_END_FRAME] = Animation_GetLastFrame(&gPhantomGanonAirDamageAnim);
                         Animation_Change(&this->skelAnime, &gPhantomGanonAirDamageAnim, 0.5f, 0.0f,
-                                         this->fwork[GND_END_FRAME], ANIMMODE_ONCE_INTERP, 0.0f);
+                                            this->fwork[GND_END_FRAME], ANIMMODE_ONCE_INTERP, 0.0f);
                         this->work[GND_ACTION_STATE] = DEATH_LIMP;
+                    } else if (gSaveContext.n64ddFlag) {
+                        // Skip to death scream animation and move ganondrof to middle
+                        this->deathState = DEATH_SCREAM;
+                        this->timers[0] = 50;
+                        Animation_MorphToLoop(&this->skelAnime, &gPhantomGanonScreamAnim, -10.0f);
+                        this->actor.world.pos.x = GND_BOSSROOM_CENTER_X;
+                        this->actor.world.pos.y = GND_BOSSROOM_CENTER_Y + 83.0f;
+                        this->actor.world.pos.z = GND_BOSSROOM_CENTER_Z;
+                        this->actor.shape.rot.y = 0;
+                        this->work[GND_BODY_DECAY_INDEX] = 0;
+                        Audio_PlayActorSound2(&this->actor, NA_SE_EN_FANTOM_LAST);
+
+                        // Move Player out of the center of the room
+                        player->actor.world.pos.x = GND_BOSSROOM_CENTER_X - 200.0f;
+                        player->actor.world.pos.z = GND_BOSSROOM_CENTER_Z;
                     }
                     break;
                 case DEATH_LIMP:
@@ -1024,6 +1039,9 @@ void BossGanondrof_Death(BossGanondrof* this, GlobalContext* globalCtx) {
                 case DEATH_HUNCHED:
                     bodyDecayLevel = 1;
                     break;
+            }
+            if (gSaveContext.n64ddFlag) {
+                break;
             }
             Math_ApproachS(&this->actor.shape.rot.y, this->work[GND_VARIANCE_TIMER] * -100, 5, 0xBB8);
             Math_ApproachF(&this->cameraNextEye.z, this->targetPos.z + 60.0f, 0.02f, 0.5f);

--- a/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganondrof/z_boss_ganondrof.c
@@ -949,7 +949,6 @@ void BossGanondrof_SetupDeath(BossGanondrof* this, GlobalContext* globalCtx) {
     this->actionFunc = BossGanondrof_Death;
     Audio_QueueSeqCmd(0x1 << 28 | SEQ_PLAYER_BGM_MAIN << 24 | 0x100FF);
     Audio_PlayActorSound2(&this->actor, NA_SE_EN_FANTOM_DEAD);
-
     this->deathState = DEATH_START;
     this->actor.flags &= ~ACTOR_FLAG_0;
     this->work[GND_VARIANCE_TIMER] = 0;
@@ -982,6 +981,7 @@ void BossGanondrof_Death(BossGanondrof* this, GlobalContext* globalCtx) {
             osSyncPrintf("7\n");
             Gameplay_ChangeCameraStatus(globalCtx, this->deathCamera, CAM_STAT_ACTIVE);
             osSyncPrintf("8\n");
+            this->deathState = DEATH_THROES;
             player->actor.speedXZ = 0.0f;
             this->timers[0] = 50;
             this->cameraEye = camera->eye;


### PR DESCRIPTION
Skips first part of the animation (that includes text boxes) when ganondrof dies, before blue warp spawns

See: https://github.com/briaguya-ai/rando-issue-tracker/issues/45