### PR TITLE
Adding ganon flavor text

### DIFF
--- a/soh/include/z64save.h
+++ b/soh/include/z64save.h
@@ -178,6 +178,8 @@ typedef struct {
     HintLocationRando hintLocations[50];
     char childAltarText[250];
     char adultAltarText[750];
+    char ganonHintText[250];
+    char ganonText[150];
     u8 seedIcons[5];
     u8 dungeonsDone[8];
     u8 trialsDone[6];

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -1443,6 +1443,8 @@ void Randomizer::LoadHintLocations(const char* spoilerFileName) {
 
     this->childAltarText = gSaveContext.childAltarText;
     this->adultAltarText = gSaveContext.adultAltarText;
+    this->ganonHintText = gSaveContext.ganonHintText;
+    this->ganonText = gSaveContext.ganonText;
 
     for (auto hintLocation : gSaveContext.hintLocations) {
         if(hintLocation.check == RC_LINKS_POCKET) break;
@@ -1862,6 +1864,14 @@ void Randomizer::ParseHintLocationsFile(const char* spoilerFileName) {
         std::string adultAltarJsonText = spoilerFileJson["adultAltarText"].get<std::string>();
         std::string formattedAdultAltarText = FormatJsonHintText(adultAltarJsonText);
         memcpy(gSaveContext.adultAltarText, formattedAdultAltarText.c_str(), formattedAdultAltarText.length());
+
+        std::string ganonHintJsonText = spoilerFileJson["ganonHintText"].get<std::string>();
+        std::string formattedGanonHintJsonText = FormatJsonHintText(ganonHintJsonText);
+        memcpy(gSaveContext.ganonHintText, formattedGanonHintJsonText.c_str(), formattedGanonHintJsonText.length());
+
+        std::string ganonJsonText = spoilerFileJson["ganonText"].get<std::string>();
+        std::string formattedGanonJsonText = FormatJsonHintText(ganonJsonText);
+        memcpy(gSaveContext.ganonText, formattedGanonJsonText.c_str(), formattedGanonJsonText.length());
 
         json hintsJson = spoilerFileJson["hints"];
         int index = 0;
@@ -2392,12 +2402,20 @@ GetItemID Randomizer::GetItemFromGet(RandomizerGet randoGet, GetItemID ogItemId)
     }
 }
 
-std::string Randomizer::GetAdultAltarText() {
+std::string Randomizer::GetAdultAltarText() const {
     return this->adultAltarText;
 }
 
-std::string Randomizer::GetChildAltarText() {
+std::string Randomizer::GetChildAltarText() const {
     return this->childAltarText;
+}
+
+std::string Randomizer::GetGanonText() const {
+    return ganonText;
+}
+
+std::string Randomizer::GetGanonHintText() const {
+    return ganonHintText;
 }
 
 std::string Randomizer::GetHintFromCheck(RandomizerCheck check) {

--- a/soh/soh/Enhancements/randomizer/randomizer.h
+++ b/soh/soh/Enhancements/randomizer/randomizer.h
@@ -14,6 +14,8 @@ class Randomizer {
     bool gettingBottledItem;
     std::string childAltarText;
     std::string adultAltarText;
+    std::string ganonHintText;
+    std::string ganonText;
     std::unordered_map<RandomizerSettingKey, u8> randoSettings;
     GetItemID GetItemFromGet(RandomizerGet randoGet, GetItemID ogItemId);
     GetItemID GetItemFromActor(s16 actorId, s16 actorParams, s16 sceneNum, GetItemID ogItemId);
@@ -34,8 +36,10 @@ class Randomizer {
     u8 GetRandoSettingValue(RandomizerSettingKey randoSettingKey);
     RandomizerCheck GetCheckFromActor(s16 actorId, s16 actorParams, s16 sceneNum);
     bool GettingItemInBottle();
-    std::string GetChildAltarText();
-    std::string GetAdultAltarText();
+    std::string GetChildAltarText() const;
+    std::string GetAdultAltarText() const;
+    std::string GetGanonText() const;
+    std::string GetGanonHintText() const;
     std::string GetHintFromCheck(RandomizerCheck check);
     GetItemID GetRandomizedItemIdFromKnownCheck(RandomizerCheck randomizerCheck, GetItemID ogId);
     GetItemID GetRandomizedItemId(GetItemID ogId, s16 actorId, s16 actorParams, s16 sceneNum);

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -98,6 +98,8 @@ u8 GetRandoSettingValue(RandomizerSettingKey randoSettingKey);
 RandomizerCheck GetCheckFromActor(s16 actorId, s16 actorParams, s16 sceneNum);
 int CopyAltarMessage(char* buffer, const int maxBufferSize);
 int CopyHintFromCheck(RandomizerCheck check, char* buffer, const int maxBufferSize);
+int CopyGanonText(char* buffer, const int maxBufferSize);
+int CopyGanonHintText(char* buffer, const int maxBufferSize);
 void LoadHintLocations(const char* spoilerFileName);
 void LoadItemLocations(const char* spoilerFileName);
 s16 GetItemModelFromId(s16 itemId);

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -78,6 +78,14 @@ void SaveManager::LoadRandomizerVersion1() {
     for (int i = 0; i < ARRAY_COUNT(gSaveContext.adultAltarText); i++) {
         SaveManager::Instance->LoadData("aat" + std::to_string(i), gSaveContext.adultAltarText[i]);
     }
+
+    for (int i = 0; i < ARRAY_COUNT(gSaveContext.ganonHintText); i++) {
+        SaveManager::Instance->LoadData("ght" + std::to_string(i), gSaveContext.ganonHintText[i]);
+    }
+
+    for (int i = 0; i < ARRAY_COUNT(gSaveContext.ganonText); i++) {
+        SaveManager::Instance->LoadData("gt" + std::to_string(i), gSaveContext.ganonText[i]);
+    }
 }
 
 void SaveManager::SaveRandomizer() {
@@ -108,6 +116,14 @@ void SaveManager::SaveRandomizer() {
 
     for (int i = 0; i < ARRAY_COUNT(gSaveContext.adultAltarText); i++) {
         SaveManager::Instance->SaveData("aat" + std::to_string(i), gSaveContext.adultAltarText[i]);
+    }
+
+    for (int i = 0; i < ARRAY_COUNT(gSaveContext.ganonHintText); i++) {
+        SaveManager::Instance->SaveData("ght" + std::to_string(i), gSaveContext.ganonHintText[i]);
+    }
+
+    for (int i = 0; i < ARRAY_COUNT(gSaveContext.ganonText); i++) {
+        SaveManager::Instance->SaveData("gt" + std::to_string(i), gSaveContext.ganonText[i]);
     }
 }
 

--- a/soh/src/code/z_message_PAL.c
+++ b/soh/src/code/z_message_PAL.c
@@ -1688,6 +1688,10 @@ void Message_OpenText(GlobalContext* globalCtx, u16 textId) {
             msgCtx->msgLength = font->msgLength = strlen(font->msgBuf);
         } else if (gSaveContext.n64ddFlag && (textId == 0x10A2 || textId == 0x10DC || textId == 0x10DD)) {
             msgCtx->msgLength = font->msgLength = CopyScrubMessage(textId, font->msgBuf, sizeof(font->msgBuf));
+        } else if (gSaveContext.n64ddFlag && textId == 0x70CB) {
+            msgCtx->msgLength = font->msgLength = CopyGanonHintText(font->msgBuf, sizeof(font->msgBuf));
+        } else if (gSaveContext.n64ddFlag && textId == 0x70CC) {
+            msgCtx->msgLength = font->msgLength = CopyGanonText(font->msgBuf, sizeof(font->msgBuf));
         } else {
             msgCtx->msgLength = font->msgLength;
             char* src = (uintptr_t)font->msgOffset;

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -560,7 +560,7 @@ void BossGanon_IntroCutscene(BossGanon* this, GlobalContext* globalCtx) {
             Gameplay_ChangeCameraStatus(globalCtx, this->csCamIndex, CAM_STAT_ACTIVE);
             this->csCamFov = 60.0f;
 
-            if (gSaveContext.eventChkInf[7] & 0x100) {
+            if (gSaveContext.eventChkInf[7] & 0x100 || gSaveContext.n64ddFlag) {
                 // watched cutscene already, skip most of it
                 this->csState = 17;
                 this->csTimer = 0;


### PR DESCRIPTION
Added the ganon hint and regular flavor text.

Additional changes:

- Added a helper function for the OTRGlobals that can be used for copying standard strings to character buffers safely (CopyStringToCharBuffer)
- Added additional protections to make sure that string copying can never unintentionally access invalid data
- Added const correctness for some functions for optimization purposes
- Fixed areas where multiple std::strings were being generated unnecessarily

One note is that the ganon texts are not formatted properly from the randomizer, so they do not have line breaks.

I noticed save files do not copy the string natively but instead copy each individual character to the save json, this creates (in the case of the adult alter text) 750 lines instead of just one. Followed current convention until feedback is given.