### PR TITLE
Autoskip the tower cutscene if settings call for tower collapse.

### DIFF
--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -2119,6 +2119,12 @@ void Cutscene_HandleConditionalTriggers(GlobalContext* globalCtx) {
                    (gEntranceTable[((void)0, gSaveContext.entranceIndex)].scene == SCENE_GANON_DEMO)) {
             Flags_SetEventChkInf(0xC7);
             gSaveContext.entranceIndex = 0x0517;
+
+            // If we are rando and tower escape skip is on, then set the flag to say we saw the towers fall
+            // and exit.
+            if (gSaveContext.n64ddFlag && GetRandoSettingValue(RSK_SKIP_TOWER_ESCAPE)) {
+                return;
+            }
             gSaveContext.cutsceneIndex = 0xFFF0;
         }
     }

--- a/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -1503,7 +1503,13 @@ void BossGanon_DeathAndTowerCutscene(BossGanon* this, GlobalContext* globalCtx) 
 
             if (this->csTimer == 180) {
                 globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->nextEntranceIndex = (gSaveContext.n64ddFlag && GetRandoSettingValue(RSK_SKIP_TOWER_ESCAPE)) ? 0x517 : 0x43F;
+                if (gSaveContext.n64ddFlag && GetRandoSettingValue(RSK_SKIP_TOWER_ESCAPE)) {
+                    Flags_SetEventChkInf(0xC7);
+                    globalCtx->nextEntranceIndex = 0x517;
+                }
+                else {
+                    globalCtx->nextEntranceIndex = 0x43F;
+                }
                 globalCtx->fadeTransition = 5;
             }
             break;


### PR DESCRIPTION
Set the proper event context flag such that we have already observed the tower collapsed.