### PR TITLE
Improved prelude after time travel fix

### DIFF
--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -237,7 +237,7 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
     if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT) && CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW) && LINK_IS_ADULT &&
         (gEntranceTable[((void)0, gSaveContext.entranceIndex)].scene == SCENE_TOKINOMA) &&
         !Flags_GetTreasure(globalCtx, 0x1E) && player != NULL && !Player_InBlockingCsMode(globalCtx, player) &&
-        globalCtx->sceneLoadFlag == 0) {
+        globalCtx->sceneLoadFlag == 0 && player->getItemId == GI_NONE) {
         GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ARROW_LIGHT);
         GiveItemWithoutActor(globalCtx, getItemId);
         Flags_SetTreasure(globalCtx, 0x1E);

--- a/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -134,7 +134,8 @@ void func_808BAF40(BgTokiSwd* this, GlobalContext* globalCtx) {
             BgTokiSwd_SetupAction(this, func_808BB0AC);
         } else {
             Player* player = GET_PLAYER(globalCtx);
-            if (Actor_IsFacingPlayer(&this->actor, 0x2000) && (gSaveContext.n64ddFlag && player->getItemId == GI_NONE)) {
+            if (Actor_IsFacingPlayer(&this->actor, 0x2000) && 
+                (!gSaveContext.n64ddFlag || (gSaveContext.n64ddFlag && player->getItemId == GI_NONE))) {
                 func_8002F580(&this->actor, globalCtx);
             }
         }

--- a/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
+++ b/soh/src/overlays/actors/ovl_Bg_Toki_Swd/z_bg_toki_swd.c
@@ -109,12 +109,6 @@ void BgTokiSwd_Destroy(Actor* thisx, GlobalContext* globalCtx) {
     BgTokiSwd* this = (BgTokiSwd*)thisx;
 
     Collider_DestroyCylinder(globalCtx, &this->collider);
-    
-    if (gSaveContext.n64ddFlag && LINK_IS_ADULT && !Gameplay_InCsMode(globalCtx)) {
-        if (CHECK_QUEST_ITEM(QUEST_MEDALLION_FOREST) && !(gSaveContext.eventChkInf[5] & 0x20)) {
-            GivePlayerRandoRewardSheikSong(this, globalCtx, RC_SHEIK_AT_TEMPLE, 0x20, GI_PRELUDE_OF_LIGHT);
-        }
-    }
 }
 
 void func_808BAF40(BgTokiSwd* this, GlobalContext* globalCtx) {
@@ -139,7 +133,8 @@ void func_808BAF40(BgTokiSwd* this, GlobalContext* globalCtx) {
             this->actor.parent = NULL;
             BgTokiSwd_SetupAction(this, func_808BB0AC);
         } else {
-            if (Actor_IsFacingPlayer(&this->actor, 0x2000)) {
+            Player* player = GET_PLAYER(globalCtx);
+            if (Actor_IsFacingPlayer(&this->actor, 0x2000) && (gSaveContext.n64ddFlag && player->getItemId == GI_NONE)) {
                 func_8002F580(&this->actor, globalCtx);
             }
         }

--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -2341,6 +2341,14 @@ void EnXc_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnXc* this = (EnXc*)thisx;
     s32 action = this->action;
 
+    if (this->actor.params == SHEIK_TYPE_9) {
+        if (gSaveContext.n64ddFlag && LINK_IS_ADULT) {
+            if (CHECK_QUEST_ITEM(QUEST_MEDALLION_FOREST) && !(gSaveContext.eventChkInf[5] & 0x20)) {
+                GivePlayerRandoRewardSheikSong(this, globalCtx, RC_SHEIK_AT_TEMPLE, 0x20, GI_PRELUDE_OF_LIGHT);
+            }
+        }
+    }
+
     if ((action < 0) || (action >= ARRAY_COUNT(sActionFuncs)) || (sActionFuncs[action] == NULL)) {
         osSyncPrintf(VT_FGCOL(RED) "メインモードがおかしい!!!!!!!!!!!!!!!!!!!!!!!!!\n" VT_RST);
     } else {

--- a/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/soh/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -272,7 +272,9 @@ void func_80B3C9EC(EnXc* this) {
     this->action = SHEIK_ACTION_BLOCK_PEDESTAL;
     this->drawMode = SHEIK_DRAW_DEFAULT;
     this->unk_30C = 1;
-    Actor_Kill(&this->actor);
+    if (gSaveContext.n64ddFlag) {
+        Actor_Kill(&this->actor);
+    }
     return;
 }
 


### PR DESCRIPTION
Finally we have the ultimate fix. Players will receive the Prelude check when meeting the requirements and time travelling forward from child link. They will also receive LACS check immediately afterwards if they meet those requirements.

Initially, the issue was that the code to trigger giving a player the item was only in Sheik's Temple of Time initializing code, so it only got called once, while the warp was happening, and wasn't able to complete, and only got called again when the player re-entered the master sword room.

My initial fix involved the master sword being the actor giving the check instead during it's destroy function, after it has already been destroyed to where the time travelling code does not trigger. This worked but was still a bit clunky.

Finally, I found the the true solution. Sheik's actor is still loaded, so it's general update function still works. First, I make sure I have the correct Sheik type, otherwise it will check for the medallion even at the other Sheik song check locations. Then, I make sure we are Adult and meet the requirements for Prelude. Finally, we give the item.

This was enough to make it work in certain situations, but there was more that needed to be done. The way the game gives Link items is that it sets a `player->getItemId` variable which is then evaluated at some point in the update cycle. Unfortunately, the master sword pedestal also does something to set the `getItemId` variable when Link is in close proximity to it. This resulted in the `getItemId` being overwritten before Link actually got the item from Sheik, but the flag to confirm we had gotten the check had already been set, so the item was lost. I edited the Master Sword pedestal's code to only do this overwrite if `player->getItemId` was `GI_NONE` (as in, we aren't already getting another item). This worked great! Link could travel forward in time, get the Prelude check, `getItemId` would get changed to `GI_NONE` naturally at the end of that, and the Master Sword pedestal still behaves normally afterwards. Then I found that the same thing happens when the player qualifies for both LACS check and Prelude check at the same time and time travels forward from child. So I applied the same fix to the LACS check code. Now the player can time travel forward, get Prelude check and LACS check, and everything behaves normally afterwards.