### PR TITLE
Added cutscene skip for zelda escaping

### DIFF
--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -490,8 +490,12 @@ void func_80065134(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdDayTim
 void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* cmd) {
     Player* player = GET_PLAYER(globalCtx);
     s32 temp = 0;
+
     // Automatically skip certain cutscenes when in rando
+    // cmd->base == 3: Zelda escaping with impa cutscene
     bool randoCsSkip = (gSaveContext.n64ddFlag && cmd->base == 33);
+    bool debugCsSkip = (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
+                        (gSaveContext.fileNum != 0xFEDC) && CVar_GetS32("gDebugEnabled", 0));
 
     if ((gSaveContext.gameMode != 0) && (gSaveContext.gameMode != 3) && (globalCtx->sceneNum != SCENE_SPOT00) &&
         (csCtx->frames > 20) &&
@@ -503,9 +507,7 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
         temp = 1;
     }
 
-    if ((csCtx->frames == cmd->startFrame) || (temp != 0) || ((csCtx->frames > 20) && (randoCsSkip ||
-        (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
-            (gSaveContext.fileNum != 0xFEDC) && CVar_GetS32("gDebugEnabled", 0))))) {
+    if ((csCtx->frames == cmd->startFrame) || (temp != 0) || ((csCtx->frames > 20) && (randoCsSkip || debugCsSkip))) {
 
         csCtx->state = CS_STATE_UNSKIPPABLE_EXEC;
         Audio_SetCutsceneFlag(0);

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -490,6 +490,8 @@ void func_80065134(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdDayTim
 void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* cmd) {
     Player* player = GET_PLAYER(globalCtx);
     s32 temp = 0;
+    // Automatically skip certain cutscenes when in rando
+    bool randoCsSkip = (gSaveContext.n64ddFlag && cmd->base == 33);
 
     if ((gSaveContext.gameMode != 0) && (gSaveContext.gameMode != 3) && (globalCtx->sceneNum != SCENE_SPOT00) &&
         (csCtx->frames > 20) &&
@@ -501,11 +503,9 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
         temp = 1;
     }
 
-    if ((csCtx->frames == cmd->startFrame) || (temp != 0) ||
-        // Skip specific cutscene in rando automatically
-        (gSaveContext.n64ddFlag && cmd->base == 33 && (csCtx->frames > 20)) ||
-        ((csCtx->frames > 20) && CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
-         (gSaveContext.fileNum != 0xFEDC)) && CVar_GetS32("gDebugEnabled", 0)) {
+    if ((csCtx->frames == cmd->startFrame) || (temp != 0) || ((csCtx->frames > 20) && (randoCsSkip ||
+        (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
+            (gSaveContext.fileNum != 0xFEDC) && CVar_GetS32("gDebugEnabled", 0))))) {
 
         csCtx->state = CS_STATE_UNSKIPPABLE_EXEC;
         Audio_SetCutsceneFlag(0);

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -518,721 +518,723 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
 
         gSaveContext.cutsceneIndex = 0;
 
-        // Skip specific cutscenes in rando automatically
-        if (!(gSaveContext.n64ddFlag) || cmd->base == 33) {
-            switch (cmd->base) {
-                case 1:
+        // Stop skipping cutscene in rando unless specific cutscene
+        if ((gSaveContext.n64ddFlag) && cmd->base != 33) {
+            return;
+        }
+
+        switch (cmd->base) {
+            case 1:
+                globalCtx->nextEntranceIndex = 0x00A0;
+                gSaveContext.cutsceneIndex = 0xFFF1;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 2:
+                globalCtx->nextEntranceIndex = 0x00A0;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 10;
+                break;
+            case 3:
+                globalCtx->nextEntranceIndex = 0x0117;
+                gSaveContext.cutsceneIndex = 0xFFF1;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 10;
+                break;
+            case 4:
+                globalCtx->nextEntranceIndex = 0x013D;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 10;
+                break;
+            case 5:
+                globalCtx->nextEntranceIndex = 0x00EE;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 10;
+                break;
+            case 6:
+                globalCtx->nextEntranceIndex = 0x00A0;
+                gSaveContext.cutsceneIndex = 0xFFF2;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 10;
+                break;
+            case 7:
+                globalCtx->nextEntranceIndex = 0x00EE;
+                gSaveContext.cutsceneIndex = 0xFFF2;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 11;
+                break;
+            case 8:
+                gSaveContext.fw.set = 0;
+                gSaveContext.respawn[RESPAWN_MODE_TOP].data = 0;
+                if (!(gSaveContext.eventChkInf[4] & 0x20)) {
+                    gSaveContext.eventChkInf[4] |= 0x20;
                     globalCtx->nextEntranceIndex = 0x00A0;
-                    gSaveContext.cutsceneIndex = 0xFFF1;
                     globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 2:
-                    globalCtx->nextEntranceIndex = 0x00A0;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 10;
-                    break;
-                case 3:
-                    globalCtx->nextEntranceIndex = 0x0117;
-                    gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 10;
-                    break;
-                case 4:
-                    globalCtx->nextEntranceIndex = 0x013D;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 10;
-                    break;
-                case 5:
-                    globalCtx->nextEntranceIndex = 0x00EE;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 10;
-                    break;
-                case 6:
-                    globalCtx->nextEntranceIndex = 0x00A0;
-                    gSaveContext.cutsceneIndex = 0xFFF2;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 10;
-                    break;
-                case 7:
-                    globalCtx->nextEntranceIndex = 0x00EE;
-                    gSaveContext.cutsceneIndex = 0xFFF2;
-                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF3;
                     globalCtx->fadeTransition = 11;
-                    break;
-                case 8:
-                    gSaveContext.fw.set = 0;
-                    gSaveContext.respawn[RESPAWN_MODE_TOP].data = 0;
-                    if (!(gSaveContext.eventChkInf[4] & 0x20)) {
-                        gSaveContext.eventChkInf[4] |= 0x20;
-                        globalCtx->nextEntranceIndex = 0x00A0;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        gSaveContext.cutsceneIndex = 0xFFF3;
-                        globalCtx->fadeTransition = 11;
-                    } else {
-                        if (gSaveContext.sceneSetupIndex < 4) {
-                            if (!LINK_IS_ADULT) {
-                                globalCtx->linkAgeOnLoad = 0;
-                            } else {
-                                globalCtx->linkAgeOnLoad = 1;
-                            }
-                        }
-                        globalCtx->nextEntranceIndex = 0x02CA;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        globalCtx->fadeTransition = 3;
-                        gSaveContext.nextTransition = 3;
-                    }
-                    break;
-                case 9:
-                    globalCtx->nextEntranceIndex = 0x0117;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 12;
-                    break;
-                case 10:
-                    globalCtx->nextEntranceIndex = 0x00BB;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 11:
-                    globalCtx->nextEntranceIndex = 0x00EE;
-                    gSaveContext.cutsceneIndex = 0xFFF3;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 12:
-                    globalCtx->nextEntranceIndex = 0x047A;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 13:
-                    globalCtx->nextEntranceIndex = 0x010E;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    gSaveContext.nextTransition = 2;
-                    break;
-                case 14:
-                    globalCtx->nextEntranceIndex = 0x0457;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 15:
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF4;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 16:
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF5;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 17:
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF6;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 18:
-                    gSaveContext.eventChkInf[4] |= 0x8000;
-                    globalCtx->nextEntranceIndex = 0x0324;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    gSaveContext.nextTransition = 2;
-                    break;
-                case 19:
-                    globalCtx->nextEntranceIndex = 0x013D;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 4;
-                    gSaveContext.cutsceneIndex = 0x8000;
-                    break;
-                case 21:
-                    globalCtx->nextEntranceIndex = 0x0102;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 22:
-                    Item_Give(globalCtx, ITEM_SONG_REQUIEM);
-                    globalCtx->nextEntranceIndex = 0x0123;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 23:
-                    globalCtx->nextEntranceIndex = 0x00A0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF8;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 24:
-                    globalCtx->nextEntranceIndex = 0x0028;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 25:
-                    globalCtx->linkAgeOnLoad = 0;
-                    globalCtx->nextEntranceIndex = 0x006B;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 26:
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF4;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 27:
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF5;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 28:
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF6;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 29:
-                    globalCtx->nextEntranceIndex = 0x006B;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.chamberCutsceneNum = 0;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 30:
-                    globalCtx->nextEntranceIndex = 0x006B;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
-                    Item_Give(globalCtx, ITEM_MEDALLION_FIRE);
-                    gSaveContext.chamberCutsceneNum = 1;
-                    break;
-                case 31:
-                    globalCtx->nextEntranceIndex = 0x006B;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
-                    gSaveContext.chamberCutsceneNum = 2;
-                    break;
-                case 32:
-                    globalCtx->linkAgeOnLoad = 1;
-                    globalCtx->nextEntranceIndex = 0x00CD;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF2;
-                    globalCtx->fadeTransition = 11;
-                    break;
-                case 33:
-                    globalCtx->nextEntranceIndex = 0x00CD;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 34:
-                    globalCtx->nextEntranceIndex = 0x00A0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF3;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 35:
-                    globalCtx->nextEntranceIndex = 0x00CD;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 38:
-                    globalCtx->nextEntranceIndex = 0x00A0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF4;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 39:
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF9;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 40:
-                    globalCtx->linkAgeOnLoad = 0;
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFFA;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 41:
-                    globalCtx->nextEntranceIndex = 0x04E6;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 42:
-                    globalCtx->nextEntranceIndex = 0x00DB;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF2;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 43:
-                    globalCtx->nextEntranceIndex = 0x0503;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 44:
-                    globalCtx->nextEntranceIndex = 0x0320;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 17;
-                    break;
-                case 46:
-                    gSaveContext.eventChkInf[4] |= 0x8000;
-                    globalCtx->nextEntranceIndex = 0x0324;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 47:
-                    Item_Give(globalCtx, ITEM_SONG_NOCTURNE);
-                    gSaveContext.eventChkInf[5] |= 0x10;
-                    globalCtx->nextEntranceIndex = 0x00DB;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 48:
-                    globalCtx->nextEntranceIndex = 0x01ED;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 15;
-                    gSaveContext.nextTransition = 15;
-                    break;
-                case 49:
-                    globalCtx->nextEntranceIndex = 0x058C;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 4;
-                    break;
-                case 50:
-                    globalCtx->nextEntranceIndex = 0x0513;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 17;
-                    break;
-                case 51:
-                    globalCtx->nextEntranceIndex = 0x00CD;
-                    gSaveContext.cutsceneIndex = 0xFFF8;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 41;
-                    break;
-                case 52:
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    gSaveContext.cutsceneIndex = 0xFFF7;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 11;
-                    break;
-                case 53:
-                    globalCtx->nextEntranceIndex = 0x050F;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 54:
-                    gSaveContext.gameMode = 3;
-                    Audio_SetSoundBanksMute(0x6F);
-                    globalCtx->linkAgeOnLoad = 1;
-                    globalCtx->nextEntranceIndex = 0x0117;
-                    gSaveContext.cutsceneIndex = 0xFFF2;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 55:
-                    globalCtx->nextEntranceIndex = 0x0129;
-                    gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 56:
-                    globalCtx->nextEntranceIndex = 0x00DB;
-                    gSaveContext.cutsceneIndex = 0xFFF4;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 57:
-                    globalCtx->nextEntranceIndex = 0x013D;
-                    gSaveContext.cutsceneIndex = 0xFFF3;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 58:
-                    globalCtx->nextEntranceIndex = 0x014D;
-                    gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 59:
-                    globalCtx->nextEntranceIndex = 0x0102;
-                    gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 60:
-                    globalCtx->nextEntranceIndex = 0x010E;
-                    gSaveContext.cutsceneIndex = 0xFFF2;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 61:
-                    globalCtx->nextEntranceIndex = 0x0108;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 62:
-                    globalCtx->linkAgeOnLoad = 0;
-                    globalCtx->nextEntranceIndex = 0x00EE;
-                    gSaveContext.cutsceneIndex = 0xFFF6;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 63:
-                    globalCtx->nextEntranceIndex = 0x00EE;
-                    gSaveContext.cutsceneIndex = 0xFFF7;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 64:
-                    globalCtx->nextEntranceIndex = 0x00CD;
-                    gSaveContext.cutsceneIndex = 0xFFF5;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 65:
-                    globalCtx->linkAgeOnLoad = 1;
-                    globalCtx->nextEntranceIndex = 0x0157;
-                    gSaveContext.cutsceneIndex = 0xFFF2;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 66:
-                    globalCtx->nextEntranceIndex = 0x0554;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 67:
-                    globalCtx->nextEntranceIndex = 0x027E;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 68:
-                    globalCtx->nextEntranceIndex = 0x00A0;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF5;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 69:
-                    globalCtx->nextEntranceIndex = 0x05E8;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 70:
-                    globalCtx->nextEntranceIndex = 0x013D;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF4;
-                    globalCtx->fadeTransition = 2;
-                    gSaveContext.nextTransition = 2;
-                    break;
-                case 71:
-                    gSaveContext.equips.equipment |= 0x0100;
-                    Player_SetEquipmentData(globalCtx, player);
-                    gSaveContext.equips.equipment |= 0x1000;
-                    Player_SetEquipmentData(globalCtx, player);
-                    globalCtx->linkAgeOnLoad = 1;
-                    globalCtx->nextEntranceIndex = 0x0053;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 72:
-                    globalCtx->nextEntranceIndex = 0x0400;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF0;
-                    globalCtx->fadeTransition = 2;
-                    gSaveContext.nextTransition = 2;
-                    break;
-                case 73:
-                    globalCtx->linkAgeOnLoad = 1;
-                    globalCtx->nextEntranceIndex = 0x0157;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF2;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 74:
-                    globalCtx->nextEntranceIndex = 0x0157;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF3;
-                    globalCtx->fadeTransition = 3;
-                    gSaveContext.nextTransition = 3;
-                    break;
-                case 75:
-                    globalCtx->linkAgeOnLoad = 1;
-                    globalCtx->nextEntranceIndex = 0x0157;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF4;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 76:
-                    globalCtx->linkAgeOnLoad = 0;
-                    globalCtx->nextEntranceIndex = 0x0157;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF5;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 77:
-                    globalCtx->linkAgeOnLoad = 1;
-                    globalCtx->nextEntranceIndex = 0x0157;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF6;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 78:
-                    globalCtx->nextEntranceIndex = 0x0157;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF7;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 79:
-                case 80:
-                case 81:
-                case 82:
-                case 83:
-                case 84:
-                case 85:
-                case 86:
-                case 87:
-                case 88:
-                case 89:
-                case 90:
-                case 91:
-                case 92:
-                case 93:
-                    globalCtx->nextEntranceIndex = 0x0157;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 94:
-                    globalCtx->nextEntranceIndex = 0x02AE;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
-                    break;
-                case 95:
-                    if ((gSaveContext.eventChkInf[4] & 0x100) && (gSaveContext.eventChkInf[4] & 0x200) &&
-                        (gSaveContext.eventChkInf[4] & 0x400)) {
-                        globalCtx->nextEntranceIndex = 0x0053;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        gSaveContext.cutsceneIndex = 0xFFF3;
-                        globalCtx->fadeTransition = 2;
-                    } else {
-                        switch (gSaveContext.sceneSetupIndex) {
-                            case 8:
-                                globalCtx->nextEntranceIndex = 0x00FC;
-                                globalCtx->sceneLoadFlag = 0x14;
-                                globalCtx->fadeTransition = 2;
-                                break;
-                            case 9:
-                                globalCtx->nextEntranceIndex = 0x0147;
-                                globalCtx->sceneLoadFlag = 0x14;
-                                globalCtx->fadeTransition = 2;
-                                break;
-                            case 10:
-                                globalCtx->nextEntranceIndex = 0x0102;
-                                globalCtx->sceneLoadFlag = 0x14;
-                                gSaveContext.cutsceneIndex = 0xFFF0;
-                                globalCtx->fadeTransition = 3;
-                                break;
+                } else {
+                    if (gSaveContext.sceneSetupIndex < 4) {
+                        if (!LINK_IS_ADULT) {
+                            globalCtx->linkAgeOnLoad = 0;
+                        } else {
+                            globalCtx->linkAgeOnLoad = 1;
                         }
                     }
-                    break;
-                case 96:
-                    if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW)) {
-                        globalCtx->nextEntranceIndex = 0x006B;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        gSaveContext.cutsceneIndex = 0xFFF1;
-                        globalCtx->fadeTransition = 5;
-                    } else {
-                        gSaveContext.eventChkInf[12] |= 0x100;
-                        globalCtx->nextEntranceIndex = 0x0610;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        globalCtx->fadeTransition = 3;
-                        gSaveContext.nextTransition = 3;
-                    }
-                    break;
-                case 97:
-                    if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT)) {
-                        globalCtx->nextEntranceIndex = 0x006B;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        gSaveContext.cutsceneIndex = 0xFFF1;
-                        globalCtx->fadeTransition = 5;
-                    } else {
-                        globalCtx->nextEntranceIndex = 0x0580;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        globalCtx->fadeTransition = 3;
-                        gSaveContext.nextTransition = 3;
-                    }
-                    break;
-                case 98:
-                    globalCtx->nextEntranceIndex = 0x0564;
+                    globalCtx->nextEntranceIndex = 0x02CA;
                     globalCtx->sceneLoadFlag = 0x14;
                     globalCtx->fadeTransition = 3;
                     gSaveContext.nextTransition = 3;
-                    break;
-                case 99:
-                    globalCtx->nextEntranceIndex = 0x0608;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    gSaveContext.nextTransition = 2;
-                    break;
-                case 100:
-                    globalCtx->nextEntranceIndex = 0x00EE;
-                    gSaveContext.cutsceneIndex = 0xFFF8;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
-                    gSaveContext.nextTransition = 3;
-                    break;
-                case 101:
-                    globalCtx->nextEntranceIndex = 0x01F5;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 15;
-                    break;
-                case 102:
-                    globalCtx->nextEntranceIndex = 0x0590;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 103:
-                    globalCtx->nextEntranceIndex = 0x00CD;
+                }
+                break;
+            case 9:
+                globalCtx->nextEntranceIndex = 0x0117;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 12;
+                break;
+            case 10:
+                globalCtx->nextEntranceIndex = 0x00BB;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 11:
+                globalCtx->nextEntranceIndex = 0x00EE;
+                gSaveContext.cutsceneIndex = 0xFFF3;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 12:
+                globalCtx->nextEntranceIndex = 0x047A;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 13:
+                globalCtx->nextEntranceIndex = 0x010E;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                gSaveContext.nextTransition = 2;
+                break;
+            case 14:
+                globalCtx->nextEntranceIndex = 0x0457;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 15:
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF4;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 16:
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF5;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 17:
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF6;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 18:
+                gSaveContext.eventChkInf[4] |= 0x8000;
+                globalCtx->nextEntranceIndex = 0x0324;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                gSaveContext.nextTransition = 2;
+                break;
+            case 19:
+                globalCtx->nextEntranceIndex = 0x013D;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 4;
+                gSaveContext.cutsceneIndex = 0x8000;
+                break;
+            case 21:
+                globalCtx->nextEntranceIndex = 0x0102;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 22:
+                Item_Give(globalCtx, ITEM_SONG_REQUIEM);
+                globalCtx->nextEntranceIndex = 0x0123;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 23:
+                globalCtx->nextEntranceIndex = 0x00A0;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF8;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 24:
+                globalCtx->nextEntranceIndex = 0x0028;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 25:
+                globalCtx->linkAgeOnLoad = 0;
+                globalCtx->nextEntranceIndex = 0x006B;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 26:
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF4;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 27:
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF5;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 28:
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF6;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 29:
+                globalCtx->nextEntranceIndex = 0x006B;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.chamberCutsceneNum = 0;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 30:
+                globalCtx->nextEntranceIndex = 0x006B;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                Item_Give(globalCtx, ITEM_MEDALLION_FIRE);
+                gSaveContext.chamberCutsceneNum = 1;
+                break;
+            case 31:
+                globalCtx->nextEntranceIndex = 0x006B;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                gSaveContext.chamberCutsceneNum = 2;
+                break;
+            case 32:
+                globalCtx->linkAgeOnLoad = 1;
+                globalCtx->nextEntranceIndex = 0x00CD;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF2;
+                globalCtx->fadeTransition = 11;
+                break;
+            case 33:
+                globalCtx->nextEntranceIndex = 0x00CD;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 34:
+                globalCtx->nextEntranceIndex = 0x00A0;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF3;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 35:
+                globalCtx->nextEntranceIndex = 0x00CD;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 38:
+                globalCtx->nextEntranceIndex = 0x00A0;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF4;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 39:
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF9;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 40:
+                globalCtx->linkAgeOnLoad = 0;
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFFA;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 41:
+                globalCtx->nextEntranceIndex = 0x04E6;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 42:
+                globalCtx->nextEntranceIndex = 0x00DB;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF2;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 43:
+                globalCtx->nextEntranceIndex = 0x0503;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 44:
+                globalCtx->nextEntranceIndex = 0x0320;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 17;
+                break;
+            case 46:
+                gSaveContext.eventChkInf[4] |= 0x8000;
+                globalCtx->nextEntranceIndex = 0x0324;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 47:
+                Item_Give(globalCtx, ITEM_SONG_NOCTURNE);
+                gSaveContext.eventChkInf[5] |= 0x10;
+                globalCtx->nextEntranceIndex = 0x00DB;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF1;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 48:
+                globalCtx->nextEntranceIndex = 0x01ED;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 15;
+                gSaveContext.nextTransition = 15;
+                break;
+            case 49:
+                globalCtx->nextEntranceIndex = 0x058C;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 4;
+                break;
+            case 50:
+                globalCtx->nextEntranceIndex = 0x0513;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 17;
+                break;
+            case 51:
+                globalCtx->nextEntranceIndex = 0x00CD;
+                gSaveContext.cutsceneIndex = 0xFFF8;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 41;
+                break;
+            case 52:
+                globalCtx->nextEntranceIndex = 0x0053;
+                gSaveContext.cutsceneIndex = 0xFFF7;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 11;
+                break;
+            case 53:
+                globalCtx->nextEntranceIndex = 0x050F;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 54:
+                gSaveContext.gameMode = 3;
+                Audio_SetSoundBanksMute(0x6F);
+                globalCtx->linkAgeOnLoad = 1;
+                globalCtx->nextEntranceIndex = 0x0117;
+                gSaveContext.cutsceneIndex = 0xFFF2;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 55:
+                globalCtx->nextEntranceIndex = 0x0129;
+                gSaveContext.cutsceneIndex = 0xFFF1;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 56:
+                globalCtx->nextEntranceIndex = 0x00DB;
+                gSaveContext.cutsceneIndex = 0xFFF4;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 57:
+                globalCtx->nextEntranceIndex = 0x013D;
+                gSaveContext.cutsceneIndex = 0xFFF3;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 58:
+                globalCtx->nextEntranceIndex = 0x014D;
+                gSaveContext.cutsceneIndex = 0xFFF1;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 59:
+                globalCtx->nextEntranceIndex = 0x0102;
+                gSaveContext.cutsceneIndex = 0xFFF1;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 60:
+                globalCtx->nextEntranceIndex = 0x010E;
+                gSaveContext.cutsceneIndex = 0xFFF2;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 61:
+                globalCtx->nextEntranceIndex = 0x0108;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 62:
+                globalCtx->linkAgeOnLoad = 0;
+                globalCtx->nextEntranceIndex = 0x00EE;
+                gSaveContext.cutsceneIndex = 0xFFF6;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 63:
+                globalCtx->nextEntranceIndex = 0x00EE;
+                gSaveContext.cutsceneIndex = 0xFFF7;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 64:
+                globalCtx->nextEntranceIndex = 0x00CD;
+                gSaveContext.cutsceneIndex = 0xFFF5;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 65:
+                globalCtx->linkAgeOnLoad = 1;
+                globalCtx->nextEntranceIndex = 0x0157;
+                gSaveContext.cutsceneIndex = 0xFFF2;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 66:
+                globalCtx->nextEntranceIndex = 0x0554;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 67:
+                globalCtx->nextEntranceIndex = 0x027E;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 68:
+                globalCtx->nextEntranceIndex = 0x00A0;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF5;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 69:
+                globalCtx->nextEntranceIndex = 0x05E8;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 70:
+                globalCtx->nextEntranceIndex = 0x013D;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF4;
+                globalCtx->fadeTransition = 2;
+                gSaveContext.nextTransition = 2;
+                break;
+            case 71:
+                gSaveContext.equips.equipment |= 0x0100;
+                Player_SetEquipmentData(globalCtx, player);
+                gSaveContext.equips.equipment |= 0x1000;
+                Player_SetEquipmentData(globalCtx, player);
+                globalCtx->linkAgeOnLoad = 1;
+                globalCtx->nextEntranceIndex = 0x0053;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF1;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 72:
+                globalCtx->nextEntranceIndex = 0x0400;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF0;
+                globalCtx->fadeTransition = 2;
+                gSaveContext.nextTransition = 2;
+                break;
+            case 73:
+                globalCtx->linkAgeOnLoad = 1;
+                globalCtx->nextEntranceIndex = 0x0157;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF2;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 74:
+                globalCtx->nextEntranceIndex = 0x0157;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF3;
+                globalCtx->fadeTransition = 3;
+                gSaveContext.nextTransition = 3;
+                break;
+            case 75:
+                globalCtx->linkAgeOnLoad = 1;
+                globalCtx->nextEntranceIndex = 0x0157;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF4;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 76:
+                globalCtx->linkAgeOnLoad = 0;
+                globalCtx->nextEntranceIndex = 0x0157;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF5;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 77:
+                globalCtx->linkAgeOnLoad = 1;
+                globalCtx->nextEntranceIndex = 0x0157;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF6;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 78:
+                globalCtx->nextEntranceIndex = 0x0157;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF7;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 79:
+            case 80:
+            case 81:
+            case 82:
+            case 83:
+            case 84:
+            case 85:
+            case 86:
+            case 87:
+            case 88:
+            case 89:
+            case 90:
+            case 91:
+            case 92:
+            case 93:
+                globalCtx->nextEntranceIndex = 0x0157;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 94:
+                globalCtx->nextEntranceIndex = 0x02AE;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 95:
+                if ((gSaveContext.eventChkInf[4] & 0x100) && (gSaveContext.eventChkInf[4] & 0x200) &&
+                    (gSaveContext.eventChkInf[4] & 0x400)) {
+                    globalCtx->nextEntranceIndex = 0x0053;
                     globalCtx->sceneLoadFlag = 0x14;
                     gSaveContext.cutsceneIndex = 0xFFF3;
                     globalCtx->fadeTransition = 2;
-                    break;
-                case 104:
-                    switch (sTitleCsState) {
-                        case 0:
-                            globalCtx->nextEntranceIndex = 0x008D;
+                } else {
+                    switch (gSaveContext.sceneSetupIndex) {
+                        case 8:
+                            globalCtx->nextEntranceIndex = 0x00FC;
                             globalCtx->sceneLoadFlag = 0x14;
-                            gSaveContext.cutsceneIndex = 0xFFF2;
                             globalCtx->fadeTransition = 2;
-                            sTitleCsState++;
                             break;
-                        case 1:
+                        case 9:
                             globalCtx->nextEntranceIndex = 0x0147;
                             globalCtx->sceneLoadFlag = 0x14;
-                            gSaveContext.cutsceneIndex = 0xFFF1;
                             globalCtx->fadeTransition = 2;
-                            sTitleCsState++;
                             break;
-                        case 2:
-                            globalCtx->nextEntranceIndex = 0x00A0;
+                        case 10:
+                            globalCtx->nextEntranceIndex = 0x0102;
                             globalCtx->sceneLoadFlag = 0x14;
-                            gSaveContext.cutsceneIndex = 0xFFF6;
-                            globalCtx->fadeTransition = 2;
-                            sTitleCsState = 0;
+                            gSaveContext.cutsceneIndex = 0xFFF0;
+                            globalCtx->fadeTransition = 3;
                             break;
                     }
-                    break;
-                case 105:
-                    globalCtx->nextEntranceIndex = 0x00E4;
+                }
+                break;
+            case 96:
+                if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW)) {
+                    globalCtx->nextEntranceIndex = 0x006B;
                     globalCtx->sceneLoadFlag = 0x14;
                     gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 106:
-                    globalCtx->nextEntranceIndex = 0x0574;
+                    globalCtx->fadeTransition = 5;
+                } else {
+                    gSaveContext.eventChkInf[12] |= 0x100;
+                    globalCtx->nextEntranceIndex = 0x0610;
                     globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 107:
-                    globalCtx->nextEntranceIndex = 0x0538;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 108:
-                    globalCtx->nextEntranceIndex = 0x053C;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 109:
-                    globalCtx->nextEntranceIndex = 0x0540;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 110:
-                    globalCtx->nextEntranceIndex = 0x0544;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 111:
-                    globalCtx->nextEntranceIndex = 0x0548;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 112:
-                    globalCtx->nextEntranceIndex = 0x054C;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 113:
-                    if (Flags_GetEventChkInf(0xBB) && Flags_GetEventChkInf(0xBC) && Flags_GetEventChkInf(0xBD) &&
-                        Flags_GetEventChkInf(0xBE) && Flags_GetEventChkInf(0xBF) && Flags_GetEventChkInf(0xAD)) {
-                        globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(gTowerBarrierCs);
-                        globalCtx->csCtx.frames = 0;
-                        gSaveContext.cutsceneTrigger = 1;
-                        gSaveContext.cutsceneIndex = 0xFFFF;
-                        csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
-                    } else {
-                        gSaveContext.cutsceneIndex = 0xFFFF;
-                        csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
-                    }
-                    break;
-                case 114:
-                    globalCtx->nextEntranceIndex = 0x0185;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    break;
-                case 115:
-                    globalCtx->nextEntranceIndex = 0x0594;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 2;
-                    gSaveContext.nextTransition = 2;
-                    break;
-                case 116:
-                    if (gSaveContext.eventChkInf[12] & 0x100) {
-                        globalCtx->nextEntranceIndex = 0x0580;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        globalCtx->fadeTransition = 3;
-                    } else {
-                        globalCtx->nextEntranceIndex = 0x0610;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        globalCtx->fadeTransition = 3;
-                    }
+                    globalCtx->fadeTransition = 3;
                     gSaveContext.nextTransition = 3;
-                    break;
-                case 117:
-                    gSaveContext.gameMode = 3;
-                    Audio_SetSoundBanksMute(0x6F);
-                    globalCtx->linkAgeOnLoad = 0;
-                    globalCtx->nextEntranceIndex = 0x00CD;
-                    gSaveContext.cutsceneIndex = 0xFFF7;
+                }
+                break;
+            case 97:
+                if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT)) {
+                    globalCtx->nextEntranceIndex = 0x006B;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF1;
+                    globalCtx->fadeTransition = 5;
+                } else {
+                    globalCtx->nextEntranceIndex = 0x0580;
                     globalCtx->sceneLoadFlag = 0x14;
                     globalCtx->fadeTransition = 3;
-                    break;
-                case 118:
-                    gSaveContext.respawn[RESPAWN_MODE_DOWN].entranceIndex = 0x0517;
-                    Gameplay_TriggerVoidOut(globalCtx);
-                    gSaveContext.respawnFlag = -2;
-                    gSaveContext.nextTransition = 2;
-                    break;
-                case 119:
-                    gSaveContext.dayTime = 0x8000;
-                    gSaveContext.skyboxTime = 0x8000;
-                    globalCtx->nextEntranceIndex = 0x05F0;
+                    gSaveContext.nextTransition = 3;
+                }
+                break;
+            case 98:
+                globalCtx->nextEntranceIndex = 0x0564;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                gSaveContext.nextTransition = 3;
+                break;
+            case 99:
+                globalCtx->nextEntranceIndex = 0x0608;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                gSaveContext.nextTransition = 2;
+                break;
+            case 100:
+                globalCtx->nextEntranceIndex = 0x00EE;
+                gSaveContext.cutsceneIndex = 0xFFF8;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                gSaveContext.nextTransition = 3;
+                break;
+            case 101:
+                globalCtx->nextEntranceIndex = 0x01F5;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 15;
+                break;
+            case 102:
+                globalCtx->nextEntranceIndex = 0x0590;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 103:
+                globalCtx->nextEntranceIndex = 0x00CD;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF3;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 104:
+                switch (sTitleCsState) {
+                    case 0:
+                        globalCtx->nextEntranceIndex = 0x008D;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        gSaveContext.cutsceneIndex = 0xFFF2;
+                        globalCtx->fadeTransition = 2;
+                        sTitleCsState++;
+                        break;
+                    case 1:
+                        globalCtx->nextEntranceIndex = 0x0147;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        gSaveContext.cutsceneIndex = 0xFFF1;
+                        globalCtx->fadeTransition = 2;
+                        sTitleCsState++;
+                        break;
+                    case 2:
+                        globalCtx->nextEntranceIndex = 0x00A0;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        gSaveContext.cutsceneIndex = 0xFFF6;
+                        globalCtx->fadeTransition = 2;
+                        sTitleCsState = 0;
+                        break;
+                }
+                break;
+            case 105:
+                globalCtx->nextEntranceIndex = 0x00E4;
+                globalCtx->sceneLoadFlag = 0x14;
+                gSaveContext.cutsceneIndex = 0xFFF1;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 106:
+                globalCtx->nextEntranceIndex = 0x0574;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 107:
+                globalCtx->nextEntranceIndex = 0x0538;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 108:
+                globalCtx->nextEntranceIndex = 0x053C;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 109:
+                globalCtx->nextEntranceIndex = 0x0540;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 110:
+                globalCtx->nextEntranceIndex = 0x0544;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 111:
+                globalCtx->nextEntranceIndex = 0x0548;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 112:
+                globalCtx->nextEntranceIndex = 0x054C;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 113:
+                if (Flags_GetEventChkInf(0xBB) && Flags_GetEventChkInf(0xBC) && Flags_GetEventChkInf(0xBD) &&
+                    Flags_GetEventChkInf(0xBE) && Flags_GetEventChkInf(0xBF) && Flags_GetEventChkInf(0xAD)) {
+                    globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(gTowerBarrierCs);
+                    globalCtx->csCtx.frames = 0;
+                    gSaveContext.cutsceneTrigger = 1;
+                    gSaveContext.cutsceneIndex = 0xFFFF;
+                    csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
+                } else {
+                    gSaveContext.cutsceneIndex = 0xFFFF;
+                    csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
+                }
+                break;
+            case 114:
+                globalCtx->nextEntranceIndex = 0x0185;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                break;
+            case 115:
+                globalCtx->nextEntranceIndex = 0x0594;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 2;
+                gSaveContext.nextTransition = 2;
+                break;
+            case 116:
+                if (gSaveContext.eventChkInf[12] & 0x100) {
+                    globalCtx->nextEntranceIndex = 0x0580;
                     globalCtx->sceneLoadFlag = 0x14;
                     globalCtx->fadeTransition = 3;
-                    break;
-            }
+                } else {
+                    globalCtx->nextEntranceIndex = 0x0610;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 3;
+                }
+                gSaveContext.nextTransition = 3;
+                break;
+            case 117:
+                gSaveContext.gameMode = 3;
+                Audio_SetSoundBanksMute(0x6F);
+                globalCtx->linkAgeOnLoad = 0;
+                globalCtx->nextEntranceIndex = 0x00CD;
+                gSaveContext.cutsceneIndex = 0xFFF7;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                break;
+            case 118:
+                gSaveContext.respawn[RESPAWN_MODE_DOWN].entranceIndex = 0x0517;
+                Gameplay_TriggerVoidOut(globalCtx);
+                gSaveContext.respawnFlag = -2;
+                gSaveContext.nextTransition = 2;
+                break;
+            case 119:
+                gSaveContext.dayTime = 0x8000;
+                gSaveContext.skyboxTime = 0x8000;
+                globalCtx->nextEntranceIndex = 0x05F0;
+                globalCtx->sceneLoadFlag = 0x14;
+                globalCtx->fadeTransition = 3;
+                break;
         }
     }
 }

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -501,11 +501,13 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
         temp = 1;
     }
 
-    // Skip cutscenes in rando automatically, or with debug + press start
     if ((csCtx->frames == cmd->startFrame) || (temp != 0) ||
-        ((csCtx->frames > 20) && (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) || (gSaveContext.n64ddFlag)) &&
+        // Skip specific cutscene in rando automatically
+        (gSaveContext.n64ddFlag && cmd->base == 33 && (csCtx->frames > 20)) ||
+        ((csCtx->frames > 20) && CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
          (gSaveContext.fileNum != 0xFEDC)) &&
-            (CVar_GetS32("gDebugEnabled", 0) || (gSaveContext.n64ddFlag))) {
+            CVar_GetS32("gDebugEnabled", 0)) {
+
         csCtx->state = CS_STATE_UNSKIPPABLE_EXEC;
         Audio_SetCutsceneFlag(0);
         gSaveContext.unk_1410 = 1;
@@ -517,11 +519,6 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
         }
 
         gSaveContext.cutsceneIndex = 0;
-
-        // Stop skipping cutscene in rando unless specific cutscene
-        if ((gSaveContext.n64ddFlag) && cmd->base != 33) {
-            return;
-        }
 
         switch (cmd->base) {
             case 1:

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -505,8 +505,7 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
         // Skip specific cutscene in rando automatically
         (gSaveContext.n64ddFlag && cmd->base == 33 && (csCtx->frames > 20)) ||
         ((csCtx->frames > 20) && CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
-         (gSaveContext.fileNum != 0xFEDC)) &&
-            CVar_GetS32("gDebugEnabled", 0)) {
+         (gSaveContext.fileNum != 0xFEDC)) && CVar_GetS32("gDebugEnabled", 0)) {
 
         csCtx->state = CS_STATE_UNSKIPPABLE_EXEC;
         Audio_SetCutsceneFlag(0);

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -501,9 +501,11 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
         temp = 1;
     }
 
+    // Skip cutscenes in rando automatically, or with debug + press start
     if ((csCtx->frames == cmd->startFrame) || (temp != 0) ||
-        ((csCtx->frames > 20) && CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
-         (gSaveContext.fileNum != 0xFEDC)) && CVar_GetS32("gDebugEnabled", 0)) {
+        ((csCtx->frames > 20) && (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) || (gSaveContext.n64ddFlag)) &&
+         (gSaveContext.fileNum != 0xFEDC)) &&
+            (CVar_GetS32("gDebugEnabled", 0) || (gSaveContext.n64ddFlag))) {
         csCtx->state = CS_STATE_UNSKIPPABLE_EXEC;
         Audio_SetCutsceneFlag(0);
         gSaveContext.unk_1410 = 1;
@@ -516,718 +518,721 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
 
         gSaveContext.cutsceneIndex = 0;
 
-        switch (cmd->base) {
-            case 1:
-                globalCtx->nextEntranceIndex = 0x00A0;
-                gSaveContext.cutsceneIndex = 0xFFF1;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 2:
-                globalCtx->nextEntranceIndex = 0x00A0;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 10;
-                break;
-            case 3:
-                globalCtx->nextEntranceIndex = 0x0117;
-                gSaveContext.cutsceneIndex = 0xFFF1;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 10;
-                break;
-            case 4:
-                globalCtx->nextEntranceIndex = 0x013D;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 10;
-                break;
-            case 5:
-                globalCtx->nextEntranceIndex = 0x00EE;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 10;
-                break;
-            case 6:
-                globalCtx->nextEntranceIndex = 0x00A0;
-                gSaveContext.cutsceneIndex = 0xFFF2;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 10;
-                break;
-            case 7:
-                globalCtx->nextEntranceIndex = 0x00EE;
-                gSaveContext.cutsceneIndex = 0xFFF2;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 11;
-                break;
-            case 8:
-                gSaveContext.fw.set = 0;
-                gSaveContext.respawn[RESPAWN_MODE_TOP].data = 0;
-                if (!(gSaveContext.eventChkInf[4] & 0x20)) {
-                    gSaveContext.eventChkInf[4] |= 0x20;
+        // Skip specific cutscenes in rando automatically
+        if (!(gSaveContext.n64ddFlag) || cmd->base == 33) {
+            switch (cmd->base) {
+                case 1:
+                    globalCtx->nextEntranceIndex = 0x00A0;
+                    gSaveContext.cutsceneIndex = 0xFFF1;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 2:
+                    globalCtx->nextEntranceIndex = 0x00A0;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 10;
+                    break;
+                case 3:
+                    globalCtx->nextEntranceIndex = 0x0117;
+                    gSaveContext.cutsceneIndex = 0xFFF1;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 10;
+                    break;
+                case 4:
+                    globalCtx->nextEntranceIndex = 0x013D;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 10;
+                    break;
+                case 5:
+                    globalCtx->nextEntranceIndex = 0x00EE;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 10;
+                    break;
+                case 6:
+                    globalCtx->nextEntranceIndex = 0x00A0;
+                    gSaveContext.cutsceneIndex = 0xFFF2;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 10;
+                    break;
+                case 7:
+                    globalCtx->nextEntranceIndex = 0x00EE;
+                    gSaveContext.cutsceneIndex = 0xFFF2;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 11;
+                    break;
+                case 8:
+                    gSaveContext.fw.set = 0;
+                    gSaveContext.respawn[RESPAWN_MODE_TOP].data = 0;
+                    if (!(gSaveContext.eventChkInf[4] & 0x20)) {
+                        gSaveContext.eventChkInf[4] |= 0x20;
+                        globalCtx->nextEntranceIndex = 0x00A0;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        gSaveContext.cutsceneIndex = 0xFFF3;
+                        globalCtx->fadeTransition = 11;
+                    } else {
+                        if (gSaveContext.sceneSetupIndex < 4) {
+                            if (!LINK_IS_ADULT) {
+                                globalCtx->linkAgeOnLoad = 0;
+                            } else {
+                                globalCtx->linkAgeOnLoad = 1;
+                            }
+                        }
+                        globalCtx->nextEntranceIndex = 0x02CA;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        globalCtx->fadeTransition = 3;
+                        gSaveContext.nextTransition = 3;
+                    }
+                    break;
+                case 9:
+                    globalCtx->nextEntranceIndex = 0x0117;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 12;
+                    break;
+                case 10:
+                    globalCtx->nextEntranceIndex = 0x00BB;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 11:
+                    globalCtx->nextEntranceIndex = 0x00EE;
+                    gSaveContext.cutsceneIndex = 0xFFF3;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 12:
+                    globalCtx->nextEntranceIndex = 0x047A;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 13:
+                    globalCtx->nextEntranceIndex = 0x010E;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    gSaveContext.nextTransition = 2;
+                    break;
+                case 14:
+                    globalCtx->nextEntranceIndex = 0x0457;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 15:
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF4;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 16:
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF5;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 17:
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF6;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 18:
+                    gSaveContext.eventChkInf[4] |= 0x8000;
+                    globalCtx->nextEntranceIndex = 0x0324;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    gSaveContext.nextTransition = 2;
+                    break;
+                case 19:
+                    globalCtx->nextEntranceIndex = 0x013D;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 4;
+                    gSaveContext.cutsceneIndex = 0x8000;
+                    break;
+                case 21:
+                    globalCtx->nextEntranceIndex = 0x0102;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 22:
+                    Item_Give(globalCtx, ITEM_SONG_REQUIEM);
+                    globalCtx->nextEntranceIndex = 0x0123;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 23:
+                    globalCtx->nextEntranceIndex = 0x00A0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF8;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 24:
+                    globalCtx->nextEntranceIndex = 0x0028;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 25:
+                    globalCtx->linkAgeOnLoad = 0;
+                    globalCtx->nextEntranceIndex = 0x006B;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 26:
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF4;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 27:
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF5;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 28:
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF6;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 29:
+                    globalCtx->nextEntranceIndex = 0x006B;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.chamberCutsceneNum = 0;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 30:
+                    globalCtx->nextEntranceIndex = 0x006B;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 3;
+                    Item_Give(globalCtx, ITEM_MEDALLION_FIRE);
+                    gSaveContext.chamberCutsceneNum = 1;
+                    break;
+                case 31:
+                    globalCtx->nextEntranceIndex = 0x006B;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 3;
+                    gSaveContext.chamberCutsceneNum = 2;
+                    break;
+                case 32:
+                    globalCtx->linkAgeOnLoad = 1;
+                    globalCtx->nextEntranceIndex = 0x00CD;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF2;
+                    globalCtx->fadeTransition = 11;
+                    break;
+                case 33:
+                    globalCtx->nextEntranceIndex = 0x00CD;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 34:
                     globalCtx->nextEntranceIndex = 0x00A0;
                     globalCtx->sceneLoadFlag = 0x14;
                     gSaveContext.cutsceneIndex = 0xFFF3;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 35:
+                    globalCtx->nextEntranceIndex = 0x00CD;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 38:
+                    globalCtx->nextEntranceIndex = 0x00A0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF4;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 39:
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF9;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 40:
+                    globalCtx->linkAgeOnLoad = 0;
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFFA;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 41:
+                    globalCtx->nextEntranceIndex = 0x04E6;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 42:
+                    globalCtx->nextEntranceIndex = 0x00DB;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF2;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 43:
+                    globalCtx->nextEntranceIndex = 0x0503;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 44:
+                    globalCtx->nextEntranceIndex = 0x0320;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 17;
+                    break;
+                case 46:
+                    gSaveContext.eventChkInf[4] |= 0x8000;
+                    globalCtx->nextEntranceIndex = 0x0324;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 47:
+                    Item_Give(globalCtx, ITEM_SONG_NOCTURNE);
+                    gSaveContext.eventChkInf[5] |= 0x10;
+                    globalCtx->nextEntranceIndex = 0x00DB;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF1;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 48:
+                    globalCtx->nextEntranceIndex = 0x01ED;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 15;
+                    gSaveContext.nextTransition = 15;
+                    break;
+                case 49:
+                    globalCtx->nextEntranceIndex = 0x058C;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 4;
+                    break;
+                case 50:
+                    globalCtx->nextEntranceIndex = 0x0513;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 17;
+                    break;
+                case 51:
+                    globalCtx->nextEntranceIndex = 0x00CD;
+                    gSaveContext.cutsceneIndex = 0xFFF8;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 41;
+                    break;
+                case 52:
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    gSaveContext.cutsceneIndex = 0xFFF7;
+                    globalCtx->sceneLoadFlag = 0x14;
                     globalCtx->fadeTransition = 11;
-                } else {
-                    if (gSaveContext.sceneSetupIndex < 4) {
-                        if (!LINK_IS_ADULT) {
-                            globalCtx->linkAgeOnLoad = 0;
-                        } else {
-                            globalCtx->linkAgeOnLoad = 1;
+                    break;
+                case 53:
+                    globalCtx->nextEntranceIndex = 0x050F;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 54:
+                    gSaveContext.gameMode = 3;
+                    Audio_SetSoundBanksMute(0x6F);
+                    globalCtx->linkAgeOnLoad = 1;
+                    globalCtx->nextEntranceIndex = 0x0117;
+                    gSaveContext.cutsceneIndex = 0xFFF2;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 55:
+                    globalCtx->nextEntranceIndex = 0x0129;
+                    gSaveContext.cutsceneIndex = 0xFFF1;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 56:
+                    globalCtx->nextEntranceIndex = 0x00DB;
+                    gSaveContext.cutsceneIndex = 0xFFF4;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 57:
+                    globalCtx->nextEntranceIndex = 0x013D;
+                    gSaveContext.cutsceneIndex = 0xFFF3;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 58:
+                    globalCtx->nextEntranceIndex = 0x014D;
+                    gSaveContext.cutsceneIndex = 0xFFF1;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 59:
+                    globalCtx->nextEntranceIndex = 0x0102;
+                    gSaveContext.cutsceneIndex = 0xFFF1;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 60:
+                    globalCtx->nextEntranceIndex = 0x010E;
+                    gSaveContext.cutsceneIndex = 0xFFF2;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 61:
+                    globalCtx->nextEntranceIndex = 0x0108;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 62:
+                    globalCtx->linkAgeOnLoad = 0;
+                    globalCtx->nextEntranceIndex = 0x00EE;
+                    gSaveContext.cutsceneIndex = 0xFFF6;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 63:
+                    globalCtx->nextEntranceIndex = 0x00EE;
+                    gSaveContext.cutsceneIndex = 0xFFF7;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 64:
+                    globalCtx->nextEntranceIndex = 0x00CD;
+                    gSaveContext.cutsceneIndex = 0xFFF5;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 65:
+                    globalCtx->linkAgeOnLoad = 1;
+                    globalCtx->nextEntranceIndex = 0x0157;
+                    gSaveContext.cutsceneIndex = 0xFFF2;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 66:
+                    globalCtx->nextEntranceIndex = 0x0554;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 67:
+                    globalCtx->nextEntranceIndex = 0x027E;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 68:
+                    globalCtx->nextEntranceIndex = 0x00A0;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF5;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 69:
+                    globalCtx->nextEntranceIndex = 0x05E8;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 70:
+                    globalCtx->nextEntranceIndex = 0x013D;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF4;
+                    globalCtx->fadeTransition = 2;
+                    gSaveContext.nextTransition = 2;
+                    break;
+                case 71:
+                    gSaveContext.equips.equipment |= 0x0100;
+                    Player_SetEquipmentData(globalCtx, player);
+                    gSaveContext.equips.equipment |= 0x1000;
+                    Player_SetEquipmentData(globalCtx, player);
+                    globalCtx->linkAgeOnLoad = 1;
+                    globalCtx->nextEntranceIndex = 0x0053;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF1;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 72:
+                    globalCtx->nextEntranceIndex = 0x0400;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF0;
+                    globalCtx->fadeTransition = 2;
+                    gSaveContext.nextTransition = 2;
+                    break;
+                case 73:
+                    globalCtx->linkAgeOnLoad = 1;
+                    globalCtx->nextEntranceIndex = 0x0157;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF2;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 74:
+                    globalCtx->nextEntranceIndex = 0x0157;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF3;
+                    globalCtx->fadeTransition = 3;
+                    gSaveContext.nextTransition = 3;
+                    break;
+                case 75:
+                    globalCtx->linkAgeOnLoad = 1;
+                    globalCtx->nextEntranceIndex = 0x0157;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF4;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 76:
+                    globalCtx->linkAgeOnLoad = 0;
+                    globalCtx->nextEntranceIndex = 0x0157;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF5;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 77:
+                    globalCtx->linkAgeOnLoad = 1;
+                    globalCtx->nextEntranceIndex = 0x0157;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF6;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 78:
+                    globalCtx->nextEntranceIndex = 0x0157;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    gSaveContext.cutsceneIndex = 0xFFF7;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 79:
+                case 80:
+                case 81:
+                case 82:
+                case 83:
+                case 84:
+                case 85:
+                case 86:
+                case 87:
+                case 88:
+                case 89:
+                case 90:
+                case 91:
+                case 92:
+                case 93:
+                    globalCtx->nextEntranceIndex = 0x0157;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 94:
+                    globalCtx->nextEntranceIndex = 0x02AE;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 3;
+                    break;
+                case 95:
+                    if ((gSaveContext.eventChkInf[4] & 0x100) && (gSaveContext.eventChkInf[4] & 0x200) &&
+                        (gSaveContext.eventChkInf[4] & 0x400)) {
+                        globalCtx->nextEntranceIndex = 0x0053;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        gSaveContext.cutsceneIndex = 0xFFF3;
+                        globalCtx->fadeTransition = 2;
+                    } else {
+                        switch (gSaveContext.sceneSetupIndex) {
+                            case 8:
+                                globalCtx->nextEntranceIndex = 0x00FC;
+                                globalCtx->sceneLoadFlag = 0x14;
+                                globalCtx->fadeTransition = 2;
+                                break;
+                            case 9:
+                                globalCtx->nextEntranceIndex = 0x0147;
+                                globalCtx->sceneLoadFlag = 0x14;
+                                globalCtx->fadeTransition = 2;
+                                break;
+                            case 10:
+                                globalCtx->nextEntranceIndex = 0x0102;
+                                globalCtx->sceneLoadFlag = 0x14;
+                                gSaveContext.cutsceneIndex = 0xFFF0;
+                                globalCtx->fadeTransition = 3;
+                                break;
                         }
                     }
-                    globalCtx->nextEntranceIndex = 0x02CA;
+                    break;
+                case 96:
+                    if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW)) {
+                        globalCtx->nextEntranceIndex = 0x006B;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        gSaveContext.cutsceneIndex = 0xFFF1;
+                        globalCtx->fadeTransition = 5;
+                    } else {
+                        gSaveContext.eventChkInf[12] |= 0x100;
+                        globalCtx->nextEntranceIndex = 0x0610;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        globalCtx->fadeTransition = 3;
+                        gSaveContext.nextTransition = 3;
+                    }
+                    break;
+                case 97:
+                    if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT)) {
+                        globalCtx->nextEntranceIndex = 0x006B;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        gSaveContext.cutsceneIndex = 0xFFF1;
+                        globalCtx->fadeTransition = 5;
+                    } else {
+                        globalCtx->nextEntranceIndex = 0x0580;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        globalCtx->fadeTransition = 3;
+                        gSaveContext.nextTransition = 3;
+                    }
+                    break;
+                case 98:
+                    globalCtx->nextEntranceIndex = 0x0564;
                     globalCtx->sceneLoadFlag = 0x14;
                     globalCtx->fadeTransition = 3;
                     gSaveContext.nextTransition = 3;
-                }
-                break;
-            case 9:
-                globalCtx->nextEntranceIndex = 0x0117;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 12;
-                break;
-            case 10:
-                globalCtx->nextEntranceIndex = 0x00BB;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 11:
-                globalCtx->nextEntranceIndex = 0x00EE;
-                gSaveContext.cutsceneIndex = 0xFFF3;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 12:
-                globalCtx->nextEntranceIndex = 0x047A;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 13:
-                globalCtx->nextEntranceIndex = 0x010E;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                gSaveContext.nextTransition = 2;
-                break;
-            case 14:
-                globalCtx->nextEntranceIndex = 0x0457;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 15:
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF4;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 16:
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF5;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 17:
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF6;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 18:
-                gSaveContext.eventChkInf[4] |= 0x8000;
-                globalCtx->nextEntranceIndex = 0x0324;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                gSaveContext.nextTransition = 2;
-                break;
-            case 19:
-                globalCtx->nextEntranceIndex = 0x013D;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 4;
-                gSaveContext.cutsceneIndex = 0x8000;
-                break;
-            case 21:
-                globalCtx->nextEntranceIndex = 0x0102;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 22:
-                Item_Give(globalCtx, ITEM_SONG_REQUIEM);
-                globalCtx->nextEntranceIndex = 0x0123;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 23:
-                globalCtx->nextEntranceIndex = 0x00A0;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF8;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 24:
-                globalCtx->nextEntranceIndex = 0x0028;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 25:
-                globalCtx->linkAgeOnLoad = 0;
-                globalCtx->nextEntranceIndex = 0x006B;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 26:
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF4;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 27:
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF5;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 28:
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF6;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 29:
-                globalCtx->nextEntranceIndex = 0x006B;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.chamberCutsceneNum = 0;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 30:
-                globalCtx->nextEntranceIndex = 0x006B;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                Item_Give(globalCtx, ITEM_MEDALLION_FIRE);
-                gSaveContext.chamberCutsceneNum = 1;
-                break;
-            case 31:
-                globalCtx->nextEntranceIndex = 0x006B;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                gSaveContext.chamberCutsceneNum = 2;
-                break;
-            case 32:
-                globalCtx->linkAgeOnLoad = 1;
-                globalCtx->nextEntranceIndex = 0x00CD;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF2;
-                globalCtx->fadeTransition = 11;
-                break;
-            case 33:
-                globalCtx->nextEntranceIndex = 0x00CD;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 34:
-                globalCtx->nextEntranceIndex = 0x00A0;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF3;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 35:
-                globalCtx->nextEntranceIndex = 0x00CD;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 38:
-                globalCtx->nextEntranceIndex = 0x00A0;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF4;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 39:
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF9;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 40:
-                globalCtx->linkAgeOnLoad = 0;
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFFA;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 41:
-                globalCtx->nextEntranceIndex = 0x04E6;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 42:
-                globalCtx->nextEntranceIndex = 0x00DB;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF2;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 43:
-                globalCtx->nextEntranceIndex = 0x0503;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 44:
-                globalCtx->nextEntranceIndex = 0x0320;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 17;
-                break;
-            case 46:
-                gSaveContext.eventChkInf[4] |= 0x8000;
-                globalCtx->nextEntranceIndex = 0x0324;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 47:
-                Item_Give(globalCtx, ITEM_SONG_NOCTURNE);
-                gSaveContext.eventChkInf[5] |= 0x10;
-                globalCtx->nextEntranceIndex = 0x00DB;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF1;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 48:
-                globalCtx->nextEntranceIndex = 0x01ED;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 15;
-                gSaveContext.nextTransition = 15;
-                break;
-            case 49:
-                globalCtx->nextEntranceIndex = 0x058C;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 4;
-                break;
-            case 50:
-                globalCtx->nextEntranceIndex = 0x0513;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 17;
-                break;
-            case 51:
-                globalCtx->nextEntranceIndex = 0x00CD;
-                gSaveContext.cutsceneIndex = 0xFFF8;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 41;
-                break;
-            case 52:
-                globalCtx->nextEntranceIndex = 0x0053;
-                gSaveContext.cutsceneIndex = 0xFFF7;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 11;
-                break;
-            case 53:
-                globalCtx->nextEntranceIndex = 0x050F;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 54:
-                gSaveContext.gameMode = 3;
-                Audio_SetSoundBanksMute(0x6F);
-                globalCtx->linkAgeOnLoad = 1;
-                globalCtx->nextEntranceIndex = 0x0117;
-                gSaveContext.cutsceneIndex = 0xFFF2;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 55:
-                globalCtx->nextEntranceIndex = 0x0129;
-                gSaveContext.cutsceneIndex = 0xFFF1;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 56:
-                globalCtx->nextEntranceIndex = 0x00DB;
-                gSaveContext.cutsceneIndex = 0xFFF4;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 57:
-                globalCtx->nextEntranceIndex = 0x013D;
-                gSaveContext.cutsceneIndex = 0xFFF3;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 58:
-                globalCtx->nextEntranceIndex = 0x014D;
-                gSaveContext.cutsceneIndex = 0xFFF1;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 59:
-                globalCtx->nextEntranceIndex = 0x0102;
-                gSaveContext.cutsceneIndex = 0xFFF1;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 60:
-                globalCtx->nextEntranceIndex = 0x010E;
-                gSaveContext.cutsceneIndex = 0xFFF2;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 61:
-                globalCtx->nextEntranceIndex = 0x0108;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 62:
-                globalCtx->linkAgeOnLoad = 0;
-                globalCtx->nextEntranceIndex = 0x00EE;
-                gSaveContext.cutsceneIndex = 0xFFF6;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 63:
-                globalCtx->nextEntranceIndex = 0x00EE;
-                gSaveContext.cutsceneIndex = 0xFFF7;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 64:
-                globalCtx->nextEntranceIndex = 0x00CD;
-                gSaveContext.cutsceneIndex = 0xFFF5;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 65:
-                globalCtx->linkAgeOnLoad = 1;
-                globalCtx->nextEntranceIndex = 0x0157;
-                gSaveContext.cutsceneIndex = 0xFFF2;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 66:
-                globalCtx->nextEntranceIndex = 0x0554;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 67:
-                globalCtx->nextEntranceIndex = 0x027E;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 68:
-                globalCtx->nextEntranceIndex = 0x00A0;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF5;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 69:
-                globalCtx->nextEntranceIndex = 0x05E8;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 70:
-                globalCtx->nextEntranceIndex = 0x013D;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF4;
-                globalCtx->fadeTransition = 2;
-                gSaveContext.nextTransition = 2;
-                break;
-            case 71:
-                gSaveContext.equips.equipment |= 0x0100;
-                Player_SetEquipmentData(globalCtx, player);
-                gSaveContext.equips.equipment |= 0x1000;
-                Player_SetEquipmentData(globalCtx, player);
-                globalCtx->linkAgeOnLoad = 1;
-                globalCtx->nextEntranceIndex = 0x0053;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF1;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 72:
-                globalCtx->nextEntranceIndex = 0x0400;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF0;
-                globalCtx->fadeTransition = 2;
-                gSaveContext.nextTransition = 2;
-                break;
-            case 73:
-                globalCtx->linkAgeOnLoad = 1;
-                globalCtx->nextEntranceIndex = 0x0157;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF2;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 74:
-                globalCtx->nextEntranceIndex = 0x0157;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF3;
-                globalCtx->fadeTransition = 3;
-                gSaveContext.nextTransition = 3;
-                break;
-            case 75:
-                globalCtx->linkAgeOnLoad = 1;
-                globalCtx->nextEntranceIndex = 0x0157;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF4;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 76:
-                globalCtx->linkAgeOnLoad = 0;
-                globalCtx->nextEntranceIndex = 0x0157;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF5;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 77:
-                globalCtx->linkAgeOnLoad = 1;
-                globalCtx->nextEntranceIndex = 0x0157;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF6;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 78:
-                globalCtx->nextEntranceIndex = 0x0157;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF7;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 79:
-            case 80:
-            case 81:
-            case 82:
-            case 83:
-            case 84:
-            case 85:
-            case 86:
-            case 87:
-            case 88:
-            case 89:
-            case 90:
-            case 91:
-            case 92:
-            case 93:
-                globalCtx->nextEntranceIndex = 0x0157;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 94:
-                globalCtx->nextEntranceIndex = 0x02AE;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 95:
-                if ((gSaveContext.eventChkInf[4] & 0x100) && (gSaveContext.eventChkInf[4] & 0x200) &&
-                    (gSaveContext.eventChkInf[4] & 0x400)) {
-                    globalCtx->nextEntranceIndex = 0x0053;
+                    break;
+                case 99:
+                    globalCtx->nextEntranceIndex = 0x0608;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    gSaveContext.nextTransition = 2;
+                    break;
+                case 100:
+                    globalCtx->nextEntranceIndex = 0x00EE;
+                    gSaveContext.cutsceneIndex = 0xFFF8;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 3;
+                    gSaveContext.nextTransition = 3;
+                    break;
+                case 101:
+                    globalCtx->nextEntranceIndex = 0x01F5;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 15;
+                    break;
+                case 102:
+                    globalCtx->nextEntranceIndex = 0x0590;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 103:
+                    globalCtx->nextEntranceIndex = 0x00CD;
                     globalCtx->sceneLoadFlag = 0x14;
                     gSaveContext.cutsceneIndex = 0xFFF3;
                     globalCtx->fadeTransition = 2;
-                } else {
-                    switch (gSaveContext.sceneSetupIndex) {
-                        case 8:
-                            globalCtx->nextEntranceIndex = 0x00FC;
+                    break;
+                case 104:
+                    switch (sTitleCsState) {
+                        case 0:
+                            globalCtx->nextEntranceIndex = 0x008D;
                             globalCtx->sceneLoadFlag = 0x14;
+                            gSaveContext.cutsceneIndex = 0xFFF2;
                             globalCtx->fadeTransition = 2;
+                            sTitleCsState++;
                             break;
-                        case 9:
+                        case 1:
                             globalCtx->nextEntranceIndex = 0x0147;
                             globalCtx->sceneLoadFlag = 0x14;
+                            gSaveContext.cutsceneIndex = 0xFFF1;
                             globalCtx->fadeTransition = 2;
+                            sTitleCsState++;
                             break;
-                        case 10:
-                            globalCtx->nextEntranceIndex = 0x0102;
+                        case 2:
+                            globalCtx->nextEntranceIndex = 0x00A0;
                             globalCtx->sceneLoadFlag = 0x14;
-                            gSaveContext.cutsceneIndex = 0xFFF0;
-                            globalCtx->fadeTransition = 3;
+                            gSaveContext.cutsceneIndex = 0xFFF6;
+                            globalCtx->fadeTransition = 2;
+                            sTitleCsState = 0;
                             break;
                     }
-                }
-                break;
-            case 96:
-                if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SHADOW)) {
-                    globalCtx->nextEntranceIndex = 0x006B;
+                    break;
+                case 105:
+                    globalCtx->nextEntranceIndex = 0x00E4;
                     globalCtx->sceneLoadFlag = 0x14;
                     gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->fadeTransition = 5;
-                } else {
-                    gSaveContext.eventChkInf[12] |= 0x100;
-                    globalCtx->nextEntranceIndex = 0x0610;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 106:
+                    globalCtx->nextEntranceIndex = 0x0574;
                     globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 107:
+                    globalCtx->nextEntranceIndex = 0x0538;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 108:
+                    globalCtx->nextEntranceIndex = 0x053C;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 109:
+                    globalCtx->nextEntranceIndex = 0x0540;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 110:
+                    globalCtx->nextEntranceIndex = 0x0544;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 111:
+                    globalCtx->nextEntranceIndex = 0x0548;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 112:
+                    globalCtx->nextEntranceIndex = 0x054C;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 113:
+                    if (Flags_GetEventChkInf(0xBB) && Flags_GetEventChkInf(0xBC) && Flags_GetEventChkInf(0xBD) &&
+                        Flags_GetEventChkInf(0xBE) && Flags_GetEventChkInf(0xBF) && Flags_GetEventChkInf(0xAD)) {
+                        globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(gTowerBarrierCs);
+                        globalCtx->csCtx.frames = 0;
+                        gSaveContext.cutsceneTrigger = 1;
+                        gSaveContext.cutsceneIndex = 0xFFFF;
+                        csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
+                    } else {
+                        gSaveContext.cutsceneIndex = 0xFFFF;
+                        csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
+                    }
+                    break;
+                case 114:
+                    globalCtx->nextEntranceIndex = 0x0185;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    break;
+                case 115:
+                    globalCtx->nextEntranceIndex = 0x0594;
+                    globalCtx->sceneLoadFlag = 0x14;
+                    globalCtx->fadeTransition = 2;
+                    gSaveContext.nextTransition = 2;
+                    break;
+                case 116:
+                    if (gSaveContext.eventChkInf[12] & 0x100) {
+                        globalCtx->nextEntranceIndex = 0x0580;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        globalCtx->fadeTransition = 3;
+                    } else {
+                        globalCtx->nextEntranceIndex = 0x0610;
+                        globalCtx->sceneLoadFlag = 0x14;
+                        globalCtx->fadeTransition = 3;
+                    }
                     gSaveContext.nextTransition = 3;
-                }
-                break;
-            case 97:
-                if (CHECK_QUEST_ITEM(QUEST_MEDALLION_SPIRIT)) {
-                    globalCtx->nextEntranceIndex = 0x006B;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    gSaveContext.cutsceneIndex = 0xFFF1;
-                    globalCtx->fadeTransition = 5;
-                } else {
-                    globalCtx->nextEntranceIndex = 0x0580;
+                    break;
+                case 117:
+                    gSaveContext.gameMode = 3;
+                    Audio_SetSoundBanksMute(0x6F);
+                    globalCtx->linkAgeOnLoad = 0;
+                    globalCtx->nextEntranceIndex = 0x00CD;
+                    gSaveContext.cutsceneIndex = 0xFFF7;
                     globalCtx->sceneLoadFlag = 0x14;
                     globalCtx->fadeTransition = 3;
-                    gSaveContext.nextTransition = 3;
-                }
-                break;
-            case 98:
-                globalCtx->nextEntranceIndex = 0x0564;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                gSaveContext.nextTransition = 3;
-                break;
-            case 99:
-                globalCtx->nextEntranceIndex = 0x0608;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                gSaveContext.nextTransition = 2;
-                break;
-            case 100:
-                globalCtx->nextEntranceIndex = 0x00EE;
-                gSaveContext.cutsceneIndex = 0xFFF8;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                gSaveContext.nextTransition = 3;
-                break;
-            case 101:
-                globalCtx->nextEntranceIndex = 0x01F5;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 15;
-                break;
-            case 102:
-                globalCtx->nextEntranceIndex = 0x0590;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 103:
-                globalCtx->nextEntranceIndex = 0x00CD;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF3;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 104:
-                switch (sTitleCsState) {
-                    case 0:
-                        globalCtx->nextEntranceIndex = 0x008D;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        gSaveContext.cutsceneIndex = 0xFFF2;
-                        globalCtx->fadeTransition = 2;
-                        sTitleCsState++;
-                        break;
-                    case 1:
-                        globalCtx->nextEntranceIndex = 0x0147;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        gSaveContext.cutsceneIndex = 0xFFF1;
-                        globalCtx->fadeTransition = 2;
-                        sTitleCsState++;
-                        break;
-                    case 2:
-                        globalCtx->nextEntranceIndex = 0x00A0;
-                        globalCtx->sceneLoadFlag = 0x14;
-                        gSaveContext.cutsceneIndex = 0xFFF6;
-                        globalCtx->fadeTransition = 2;
-                        sTitleCsState = 0;
-                        break;
-                }
-                break;
-            case 105:
-                globalCtx->nextEntranceIndex = 0x00E4;
-                globalCtx->sceneLoadFlag = 0x14;
-                gSaveContext.cutsceneIndex = 0xFFF1;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 106:
-                globalCtx->nextEntranceIndex = 0x0574;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 107:
-                globalCtx->nextEntranceIndex = 0x0538;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 108:
-                globalCtx->nextEntranceIndex = 0x053C;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 109:
-                globalCtx->nextEntranceIndex = 0x0540;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 110:
-                globalCtx->nextEntranceIndex = 0x0544;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 111:
-                globalCtx->nextEntranceIndex = 0x0548;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 112:
-                globalCtx->nextEntranceIndex = 0x054C;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 113:
-                if (Flags_GetEventChkInf(0xBB) && Flags_GetEventChkInf(0xBC) && Flags_GetEventChkInf(0xBD) &&
-                    Flags_GetEventChkInf(0xBE) && Flags_GetEventChkInf(0xBF) && Flags_GetEventChkInf(0xAD)) {
-                    globalCtx->csCtx.segment = SEGMENTED_TO_VIRTUAL(gTowerBarrierCs);
-                    globalCtx->csCtx.frames = 0;
-                    gSaveContext.cutsceneTrigger = 1;
-                    gSaveContext.cutsceneIndex = 0xFFFF;
-                    csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
-                } else {
-                    gSaveContext.cutsceneIndex = 0xFFFF;
-                    csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
-                }
-                break;
-            case 114:
-                globalCtx->nextEntranceIndex = 0x0185;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                break;
-            case 115:
-                globalCtx->nextEntranceIndex = 0x0594;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 2;
-                gSaveContext.nextTransition = 2;
-                break;
-            case 116:
-                if (gSaveContext.eventChkInf[12] & 0x100) {
-                    globalCtx->nextEntranceIndex = 0x0580;
+                    break;
+                case 118:
+                    gSaveContext.respawn[RESPAWN_MODE_DOWN].entranceIndex = 0x0517;
+                    Gameplay_TriggerVoidOut(globalCtx);
+                    gSaveContext.respawnFlag = -2;
+                    gSaveContext.nextTransition = 2;
+                    break;
+                case 119:
+                    gSaveContext.dayTime = 0x8000;
+                    gSaveContext.skyboxTime = 0x8000;
+                    globalCtx->nextEntranceIndex = 0x05F0;
                     globalCtx->sceneLoadFlag = 0x14;
                     globalCtx->fadeTransition = 3;
-                } else {
-                    globalCtx->nextEntranceIndex = 0x0610;
-                    globalCtx->sceneLoadFlag = 0x14;
-                    globalCtx->fadeTransition = 3;
-                }
-                gSaveContext.nextTransition = 3;
-                break;
-            case 117:
-                gSaveContext.gameMode = 3;
-                Audio_SetSoundBanksMute(0x6F);
-                globalCtx->linkAgeOnLoad = 0;
-                globalCtx->nextEntranceIndex = 0x00CD;
-                gSaveContext.cutsceneIndex = 0xFFF7;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                break;
-            case 118:
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].entranceIndex = 0x0517;
-                Gameplay_TriggerVoidOut(globalCtx);
-                gSaveContext.respawnFlag = -2;
-                gSaveContext.nextTransition = 2;
-                break;
-            case 119:
-                gSaveContext.dayTime = 0x8000;
-                gSaveContext.skyboxTime = 0x8000;
-                globalCtx->nextEntranceIndex = 0x05F0;
-                globalCtx->sceneLoadFlag = 0x14;
-                globalCtx->fadeTransition = 3;
-                break;
+                    break;
+            }
         }
     }
 }

--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -492,7 +492,7 @@ void Cutscene_Command_Terminator(GlobalContext* globalCtx, CutsceneContext* csCt
     s32 temp = 0;
 
     // Automatically skip certain cutscenes when in rando
-    // cmd->base == 3: Zelda escaping with impa cutscene
+    // cmd->base == 33: Zelda escaping with impa cutscene
     bool randoCsSkip = (gSaveContext.n64ddFlag && cmd->base == 33);
     bool debugCsSkip = (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_START) &&
                         (gSaveContext.fileNum != 0xFEDC) && CVar_GetS32("gDebugEnabled", 0));

--- a/soh/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
+++ b/soh/src/overlays/actors/ovl_Bg_Spot00_Hanebasi/z_bg_spot00_hanebasi.c
@@ -79,8 +79,9 @@ void BgSpot00Hanebasi_Init(Actor* thisx, GlobalContext* globalCtx) {
         }
 
         if (gSaveContext.sceneSetupIndex != 6) {
+            // Don't close the bridge in rando to accomodate hyrule castle exit
             if (CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD) && CHECK_QUEST_ITEM(QUEST_GORON_RUBY) &&
-                CHECK_QUEST_ITEM(QUEST_ZORA_SAPPHIRE) && !(gSaveContext.eventChkInf[8] & 1)) {
+                CHECK_QUEST_ITEM(QUEST_ZORA_SAPPHIRE) && !(gSaveContext.eventChkInf[8] & 1) && !(gSaveContext.n64ddFlag)) {
                 this->dyna.actor.shape.rot.x = -0x4000;
             }
         }


### PR DESCRIPTION
Using the debug cutscene skipping function. Also added a conditional so the bridge doesn't spawn closed when cutscene is ready to trigger so you don't fall straight into the water if you come from hyrule market when the cutscene is ready to trigger.

The way I'm hijacking the debug cutscene skip _feels_ a bit dirty, especially if we're ever going to use the same method for other cutscene skips. So if there's a better way of doing it, lemme know.

This makes it identical to the N64 cutscene skip. If we want to make it more fancy we can take a look at it later. This is fine for now I'd say.

Looks like this in game: https://cdn.discordapp.com/attachments/988962246585634856/993160744948465664/2022-07-03_16-24-26.mp4

https://github.com/briaguya-ai/rando-issue-tracker/issues/57