### PR TITLE
Fixes Saria's Gift on the LW Bridge from getting killed when holding shield

### DIFF
--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -247,11 +247,11 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
 void GivePlayerRandoRewardSariaGift(GlobalContext* globalCtx, RandomizerCheck check) {
     Player* player = GET_PLAYER(globalCtx);
 
-    if (gSaveContext.entranceIndex == 0x05E0 && !Flags_GetEventChkInf(0xC1) && player != NULL &&
+    if (gSaveContext.entranceIndex == 0x05E0 && (!Flags_GetEventChkInf(0xC1) || player->getItemId != GI_NONE) && player != NULL &&
         !Player_InBlockingCsMode(globalCtx, player)) {
-            GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ZELDAS_LULLABY);
-            GiveItemWithoutActor(globalCtx, getItemId);
-            Flags_SetEventChkInf(0xC1);
+        GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ZELDAS_LULLABY);
+        GiveItemWithoutActor(globalCtx, getItemId);
+        Flags_SetEventChkInf(0xC1);
     }
 }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -246,12 +246,14 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
 
 void GivePlayerRandoRewardSariaGift(GlobalContext* globalCtx, RandomizerCheck check) {
     Player* player = GET_PLAYER(globalCtx);
-    GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ZELDAS_LULLABY);
+    if (gSaveContext.entranceIndex == 0x05E0) {
+        GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ZELDAS_LULLABY);
 
-    if (gSaveContext.entranceIndex == 0x05E0 && (!Flags_GetEventChkInf(0xC1) || player->getItemId == getItemId) && player != NULL &&
-        !Player_InBlockingCsMode(globalCtx, player)) {
-        GiveItemWithoutActor(globalCtx, getItemId);
-        Flags_SetEventChkInf(0xC1);
+        if ((!Flags_GetEventChkInf(0xC1) || player->getItemId == getItemId) &&
+            player != NULL && !Player_InBlockingCsMode(globalCtx, player)) {
+            GiveItemWithoutActor(globalCtx, getItemId);
+            Flags_SetEventChkInf(0xC1);
+        }
     }
 }
 

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -246,10 +246,10 @@ void GivePlayerRandoRewardZeldaLightArrowsGift(GlobalContext* globalCtx, Randomi
 
 void GivePlayerRandoRewardSariaGift(GlobalContext* globalCtx, RandomizerCheck check) {
     Player* player = GET_PLAYER(globalCtx);
+    GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ZELDAS_LULLABY);
 
-    if (gSaveContext.entranceIndex == 0x05E0 && (!Flags_GetEventChkInf(0xC1) || player->getItemId != GI_NONE) && player != NULL &&
+    if (gSaveContext.entranceIndex == 0x05E0 && (!Flags_GetEventChkInf(0xC1) || player->getItemId == getItemId) && player != NULL &&
         !Player_InBlockingCsMode(globalCtx, player)) {
-        GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ZELDAS_LULLABY);
         GiveItemWithoutActor(globalCtx, getItemId);
         Flags_SetEventChkInf(0xC1);
     }

--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -249,7 +249,7 @@ void GivePlayerRandoRewardSariaGift(GlobalContext* globalCtx, RandomizerCheck ch
     if (gSaveContext.entranceIndex == 0x05E0) {
         GetItemID getItemId = GetRandomizedItemIdFromKnownCheck(check, GI_ZELDAS_LULLABY);
 
-        if ((!Flags_GetEventChkInf(0xC1) || player->getItemId == getItemId) &&
+        if ((!Flags_GetEventChkInf(0xC1) || (player->getItemId == getItemId && getItemId != GI_ICE_TRAP)) &&
             player != NULL && !Player_InBlockingCsMode(globalCtx, player)) {
             GiveItemWithoutActor(globalCtx, getItemId);
             Flags_SetEventChkInf(0xC1);


### PR DESCRIPTION
The crux of the fix is that if the shield causes the player to not receive the item, the player's getItemId doesn't get reset to GI_NONE. So I allow the item giving code to run again even if the flag has been set if the player's getItemId value is not GI_NONE. Once we are successfully given the check, the player's getItemId is set back to GI_NONE and I believe there isn't any situation in which that getItemId ever gets moved off of GI_NONE in that area. There may be a cleaner fix if this is not sufficient, but it will take me a while to find.