### PR TITLE
Fixes Door of Time opening cutscene after warping with prelude.

### DIFF
--- a/soh/src/code/z_demo.c
+++ b/soh/src/code/z_demo.c
@@ -244,7 +244,7 @@ void func_80064824(GlobalContext* globalCtx, CutsceneContext* csCtx, CsCmdBase* 
         case 3:
             if (sp3F != 0) {
                 Flags_SetEnv(globalCtx, 0);
-                if (gSaveContext.entranceIndex == 0x0053) {
+                if (gSaveContext.entranceIndex == 0x0053 || (gSaveContext.n64ddFlag && gSaveContext.entranceIndex == 0x05F4)) {
                     Flags_SetEnv(globalCtx, 2);
                 }
             }

--- a/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/soh/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -631,7 +631,7 @@ void DemoEffect_UpdateGetItem(DemoEffect* this, GlobalContext* globalCtx) {
 
         Actor_SetScale(thisx, 0.20f);
 
-        if (gSaveContext.entranceIndex == 0x0053) {
+        if (gSaveContext.entranceIndex == 0x0053 || (gSaveContext.n64ddFlag && gSaveContext.entranceIndex == 0x05F4)) {
             switch (globalCtx->csCtx.npcActions[this->csActionId]->action) {
                 case 2:
                     DemoEffect_MedalSparkle(this, globalCtx, 0);
@@ -643,7 +643,8 @@ void DemoEffect_UpdateGetItem(DemoEffect* this, GlobalContext* globalCtx) {
         }
         switch (globalCtx->csCtx.npcActions[this->csActionId]->action) {
             case 2:
-                if (gSaveContext.entranceIndex == 0x0053) {
+                if (gSaveContext.entranceIndex == 0x0053 ||
+                    (gSaveContext.n64ddFlag && gSaveContext.entranceIndex == 0x05F4)) {
                     Audio_PlayActorSound2(thisx, NA_SE_EV_MEDAL_APPEAR_L - SFX_FLAG);
                 } else {
                     func_800788CC(NA_SE_EV_MEDAL_APPEAR_S - SFX_FLAG);
@@ -658,7 +659,8 @@ void DemoEffect_UpdateGetItem(DemoEffect* this, GlobalContext* globalCtx) {
                 if (this->getItem.drawId != GID_ARROW_LIGHT) {
                     this->actor.shape.rot.y += this->getItem.rotation;
                 }
-                if (gSaveContext.entranceIndex == 0x0053) {
+                if (gSaveContext.entranceIndex == 0x0053 ||
+                    (gSaveContext.n64ddFlag && gSaveContext.entranceIndex == 0x05F4)) {
                     Audio_PlayActorSound2(thisx, NA_SE_EV_MEDAL_APPEAR_L - SFX_FLAG);
                 } else {
                     func_800788CC(NA_SE_EV_MEDAL_APPEAR_S - SFX_FLAG);
@@ -1581,14 +1583,15 @@ void DemoEffect_UpdateJewelChild(DemoEffect* this, GlobalContext* globalCtx) {
                 return;
             default:
                 DemoEffect_MoveToCsEndpoint(this, globalCtx, this->csActionId, 0);
-                if (gSaveContext.entranceIndex == 0x0053) {
+                if (gSaveContext.entranceIndex == 0x0053 ||
+                    (gSaveContext.n64ddFlag && gSaveContext.entranceIndex == 0x05F4)) {
                     DemoEffect_MoveJewelSplit(&thisx->world, this);
                 }
                 break;
         }
     }
 
-    if (gSaveContext.entranceIndex == 0x0053) {
+    if (gSaveContext.entranceIndex == 0x0053 || (gSaveContext.n64ddFlag && gSaveContext.entranceIndex == 0x05F4)) {
         if (!(gSaveContext.eventChkInf[4] & 0x800)) {
             hasCmdAction = globalCtx->csCtx.state && globalCtx->csCtx.npcActions[this->csActionId];
             if (!hasCmdAction) {


### PR DESCRIPTION
Most of the effects, including EnvFlag being set for opening the Door of Time, were locked behind checks for the entranceIndex of the Temple of Time's main entrance. This adds the prelude warp entrance to those if checks so that everything plays correctly if the player warps in through prelude instead of walking through the door.

Technically the cutscene is still missing some white-out sound effects, but I couldn't make them play without the sound effect also playing during the prelude warp.