### PR TITLE
Ganon's Castle Fixes

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -2475,7 +2475,15 @@ namespace Settings {
     BridgeDungeonCount.SetSelectedIndex(cvarSettings[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT]);
     BridgeTokenCount.SetSelectedIndex(cvarSettings[RSK_RAINBOW_BRIDGE_TOKEN_COUNT]);
     RandomGanonsTrials.SetSelectedIndex(cvarSettings[RSK_RANDOM_TRIALS]);
-    GanonsTrialsCount.SetSelectedIndex(cvarSettings[RSK_TRIAL_COUNT]);
+    //GanonsTrialsCount.SetSelectedIndex(cvarSettings[RSK_TRIAL_COUNT]);
+    switch (cvarSettings[RSK_TRIAL_COUNT]) { 
+        case 0:
+            GanonsTrialsCount.SetSelectedIndex(6);
+            break;
+        case 1:
+            GanonsTrialsCount.SetSelectedIndex(0);
+            break;
+    }
 
     ShuffleRewards.SetSelectedIndex(cvarSettings[RSK_SHUFFLE_DUNGEON_REWARDS]);
     ShuffleSongs.SetSelectedIndex(cvarSettings[RSK_SHUFFLE_SONGS]);

--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -2475,6 +2475,7 @@ namespace Settings {
     BridgeDungeonCount.SetSelectedIndex(cvarSettings[RSK_RAINBOW_BRIDGE_DUNGEON_COUNT]);
     BridgeTokenCount.SetSelectedIndex(cvarSettings[RSK_RAINBOW_BRIDGE_TOKEN_COUNT]);
     RandomGanonsTrials.SetSelectedIndex(cvarSettings[RSK_RANDOM_TRIALS]);
+    // RANDTODO: Switch this back once Ganon's Trials Count is properly implemented.
     //GanonsTrialsCount.SetSelectedIndex(cvarSettings[RSK_TRIAL_COUNT]);
     switch (cvarSettings[RSK_TRIAL_COUNT]) { 
         case 0:

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3694,7 +3694,8 @@ void DrawRandoEditor(bool& open) {
                             //SohImGui::EnhancementSliderInt("Ganon's Trial Count: %d", "##RandoTrialCount",
                             //                               "gRandomizeGanonTrialCount", 0, 6, "");
                             //InsertHelpHoverText("Set the number of trials required to enter\nGanon's Tower.");
-                        SohImGui::EnhancementCheckbox("Skip Ganon's Trials?", "gRandomizeGanonTrialCount");
+                        // RANDTODO: Switch back to slider when pre-completing some of Ganon's Trials is properly implemnted.
+                        SohImGui::EnhancementCheckbox("Skip Ganon's Trials", "gRandomizeGanonTrialCount");
                         InsertHelpHoverText(
                             "Sets whether or not Ganon's Castle Trials are required\nto enter Ganon's Tower.");
 

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -3691,9 +3691,12 @@ void DrawRandoEditor(bool& open) {
                         SohImGui::EnhancementCombobox("gRandomizeGanonTrial", randoGanonsTrial, 2, 0);
                         if (CVar_GetS32("gRandomizeGanonTrial", 0) == 0) {
                         */
-                            SohImGui::EnhancementSliderInt("Ganon's Trial Count: %d", "##RandoTrialCount",
-                                                           "gRandomizeGanonTrialCount", 0, 6, "");
-                            InsertHelpHoverText("Set the number of trials required to enter\nGanon's Tower.");
+                            //SohImGui::EnhancementSliderInt("Ganon's Trial Count: %d", "##RandoTrialCount",
+                            //                               "gRandomizeGanonTrialCount", 0, 6, "");
+                            //InsertHelpHoverText("Set the number of trials required to enter\nGanon's Tower.");
+                        SohImGui::EnhancementCheckbox("Skip Ganon's Trials?", "gRandomizeGanonTrialCount");
+                        InsertHelpHoverText(
+                            "Sets whether or not Ganon's Castle Trials are required\nto enter Ganon's Tower.");
 
                         // }
                         ImGui::Separator();

--- a/soh/src/code/z_sram.c
+++ b/soh/src/code/z_sram.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #define NUM_DUNGEONS 8
+#define NUM_TRIALS 6
 
 /**
  *  Initialize new save.
@@ -608,6 +609,11 @@ void Sram_InitSave(FileChooseContext* fileChooseCtx) {
         // Sets all the dungeons to incomplete when generating a rando save. Fixes https://github.com/briaguya-ai/rando-issue-tracker/issues/82
         for (u8 i = 0; i < NUM_DUNGEONS; i++) {
             gSaveContext.dungeonsDone[i] = 0;
+        }
+
+        // Sets all Ganon's Trials to incomplete when generating a rando save. Fixes https://github.com/briaguya-ai/rando-issue-tracker/issues/131
+        for (u8 i = 0; i < NUM_TRIALS; i++) {
+            gSaveContext.trialsDone[i] = 0;
         }
 
         // Set Cutscene flags to skip them

--- a/soh/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.c
+++ b/soh/src/overlays/actors/ovl_Demo_Kekkai/z_demo_kekkai.c
@@ -241,6 +241,7 @@ void DemoKekkai_Update(Actor* thisx, GlobalContext* globalCtx2) {
 }
 
 void DemoKekkai_TrialBarrierDispel(Actor* thisx, GlobalContext* globalCtx) {
+    static s32 eventFlags[] = { 0xC3, 0xBC, 0xBF, 0xBE, 0xBD, 0xAD, 0xBB };
     static u16 csFrames[] = { 0, 280, 280, 280, 280, 280, 280 };
     s32 pad;
     DemoKekkai* this = (DemoKekkai*)thisx;
@@ -266,6 +267,7 @@ void DemoKekkai_TrialBarrierDispel(Actor* thisx, GlobalContext* globalCtx) {
                 gSaveContext.trialsDone[0] = 1;
                 break;
         }
+        Flags_SetEventChkInf(eventFlags[thisx->params]);
     }
 
     if (globalCtx->csCtx.frames == csFrames[this->actor.params]) {


### PR DESCRIPTION
The goal of this PR is the following.

1. Change the UI so that players can only do all of Ganon's Trials or none of them, until we can implement the logic for which of Ganon's trials should be already complete on a new save file.
2. Prevent `gSaveContext.trialsDone` from having leftover values from previous save files during save generation. Similar fix to #299 
3. Fix the Beams overtop of the trial doors. They currently do not disappear when the trials are completed. This is purely visual, and may not be done in time before this PR gets merged. The first two issues are already fixed in the current set of commits.

Fixes: https://github.com/briaguya-ai/rando-issue-tracker/issues/131 and https://github.com/briaguya-ai/rando-issue-tracker/issues/132