### PR TITLE
Fixes misleading sound effects with Door of Time "Intended" setting

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -234,7 +234,7 @@ void func_80ABF4C8(EnOkarinaTag* this, GlobalContext* globalCtx) {
     if (globalCtx->msgCtx.ocarinaMode == OCARINA_MODE_04) {
         this->actionFunc = func_80ABF28C;
     } else if (globalCtx->msgCtx.ocarinaMode == OCARINA_MODE_03) {
-        if (gSaveContext.n64ddFlag || (gSaveContext.n64ddFlag && GetRandoSettingValue(RSK_DOOR_OF_TIME) != 2)) {
+        if (!gSaveContext.n64ddFlag || (gSaveContext.n64ddFlag && GetRandoSettingValue(RSK_DOOR_OF_TIME) != 2)) {
             func_80078884(NA_SE_SY_CORRECT_CHIME);
         }
         if (this->switchFlag >= 0) {
@@ -262,6 +262,7 @@ void func_80ABF4C8(EnOkarinaTag* this, GlobalContext* globalCtx) {
                         (INV_CONTENT(ITEM_OCARINA_FAIRY) != ITEM_OCARINA_TIME ||
                          !CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD) || !CHECK_QUEST_ITEM(QUEST_GORON_RUBY) ||
                          !CHECK_QUEST_ITEM(QUEST_ZORA_SAPPHIRE))) {
+                        func_80078884(NA_SE_SY_OCARINA_ERROR);
                         break;
                     } else {
                         func_80078884(NA_SE_SY_CORRECT_CHIME);

--- a/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/soh/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -234,7 +234,9 @@ void func_80ABF4C8(EnOkarinaTag* this, GlobalContext* globalCtx) {
     if (globalCtx->msgCtx.ocarinaMode == OCARINA_MODE_04) {
         this->actionFunc = func_80ABF28C;
     } else if (globalCtx->msgCtx.ocarinaMode == OCARINA_MODE_03) {
-        func_80078884(NA_SE_SY_CORRECT_CHIME);
+        if (gSaveContext.n64ddFlag || (gSaveContext.n64ddFlag && GetRandoSettingValue(RSK_DOOR_OF_TIME) != 2)) {
+            func_80078884(NA_SE_SY_CORRECT_CHIME);
+        }
         if (this->switchFlag >= 0) {
             Flags_SetSwitch(globalCtx, this->switchFlag);
         }
@@ -261,6 +263,8 @@ void func_80ABF4C8(EnOkarinaTag* this, GlobalContext* globalCtx) {
                          !CHECK_QUEST_ITEM(QUEST_KOKIRI_EMERALD) || !CHECK_QUEST_ITEM(QUEST_GORON_RUBY) ||
                          !CHECK_QUEST_ITEM(QUEST_ZORA_SAPPHIRE))) {
                         break;
+                    } else {
+                        func_80078884(NA_SE_SY_CORRECT_CHIME);
                     }
                 }
                 globalCtx->csCtx.segment = D_80ABFB40;


### PR DESCRIPTION
When playing the Song of Time in front of the altar in the Temple of Time, a "Correct Chime" is always played, because vanilla doesn't check for anything but the Song of Time (you can even use OI with no ocarina at all, I believe). This removes that sound effect when Door of Time is set to "Intended" (or option 2, may soon be changed to "Closed" if certain other PRs get merged in the future), and plays the Ocarina Error sound (a kind of "Bonk" sound effect) instead when the correct conditions are met. The correct chime still plays when the player has the Ocarina of Time and the 3 Spiritual Stones.