### PR TITLE
Added GtG and Inside Gerudo Fortress to wondertalk skip

### DIFF
--- a/soh/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
+++ b/soh/src/overlays/actors/ovl_En_Wonder_Talk2/z_en_wonder_talk2.c
@@ -252,12 +252,18 @@ void func_80B3A4F8(EnWonderTalk2* this, GlobalContext* globalCtx) {
             }
             this->unk_158 = 0;
             if (!this->unk_156) {
-                // whether or not to skip the text in rando
+                // Whether or not to skip the text in rando
                 bool randoSkipText = false;
                 if (gSaveContext.n64ddFlag) {
-                    // scenes for which all of this type of wonder talk should be skipped.
+                    // Scenes for which all of this type of wonder talk should be skipped.
                     switch (globalCtx->sceneNum) { 
-                        case 0x0007: //shadow temple
+                        case 0x0007: // Shadow Temple
+                            randoSkipText = true;
+                            break;
+                        case 0x000B: // Gerudo Training Grounds
+                            randoSkipText = true;
+                            break;
+                        case 0x000C: // Inside Gerudo Fortress
                             randoSkipText = true;
                             break;
                         default:


### PR DESCRIPTION
Checked if they were the right scene ID, text boxes are definitely skipped in those places now.

Related issues:
https://github.com/briaguya-ai/rando-issue-tracker/issues/77
https://github.com/briaguya-ai/rando-issue-tracker/issues/76