### PR TITLE
trying to figure out an audio crash

### DIFF
--- a/soh/soh/resource/importer/AudioSampleFactory.cpp
+++ b/soh/soh/resource/importer/AudioSampleFactory.cpp
@@ -32,11 +32,11 @@ void Ship::AudioSampleFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader> r
 	std::shared_ptr<AudioSample> audioSample = std::static_pointer_cast<AudioSample>(resource);
 	ResourceVersionFactory::ParseFileBinary(reader, audioSample);
 
-    audioSample->sample.codec = reader->ReadUByte();
-    audioSample->sample.medium = reader->ReadUByte();
-    audioSample->sample.unk_bit26 = reader->ReadUByte();
-    audioSample->sample.unk_bit25 = reader->ReadUByte();
-    audioSample->sample.size = reader->ReadUInt32();
+    audioSample->sample.codec = reader->ReadInt8();
+    audioSample->sample.medium = reader->ReadInt8();
+    audioSample->sample.unk_bit26 = reader->ReadInt8();
+    audioSample->sample.unk_bit25 = reader->ReadInt8();
+    audioSample->sample.size = reader->ReadInt32();
 
     audioSample->audioSampleData.reserve(audioSample->sample.size);
     for (uint32_t i = 0; i < audioSample->sample.size; i++) {
@@ -59,7 +59,7 @@ void Ship::AudioSampleFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader> r
 
     audioSample->book.order = reader->ReadInt32();
     audioSample->book.npredictors = reader->ReadInt32();
-    audioSample->bookDataCount = reader->ReadUInt32();
+    audioSample->bookDataCount = reader->ReadInt32();
 
     audioSample->bookData.reserve(audioSample->bookDataCount);
     for (uint32_t i = 0; i < audioSample->bookDataCount; i++) {

--- a/soh/soh/resource/importer/AudioSequenceFactory.cpp
+++ b/soh/soh/resource/importer/AudioSequenceFactory.cpp
@@ -35,7 +35,7 @@ void Ship::AudioSequenceFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader>
     audioSequence->sequence.seqDataSize = reader->ReadInt32();
     audioSequence->sequenceData.reserve(audioSequence->sequence.seqDataSize);
     for (uint32_t i = 0; i < audioSequence->sequence.seqDataSize; i++) {
-        audioSequence->sequenceData.push_back(reader->ReadChar());
+        audioSequence->sequenceData.push_back(reader->ReadUByte());
     }
     audioSequence->sequence.seqData = audioSequence->sequenceData.data();
     
@@ -43,7 +43,7 @@ void Ship::AudioSequenceFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader>
     audioSequence->sequence.medium = reader->ReadUByte();
     audioSequence->sequence.cachePolicy = reader->ReadUByte();
 
-    audioSequence->sequence.numFonts = reader->ReadUInt32();
+    audioSequence->sequence.numFonts = reader->ReadInt32();
     for (uint32_t i = 0; i < 16; i++) {
         audioSequence->sequence.fonts[i] = 0;
     }

--- a/soh/soh/resource/importer/AudioSoundFontFactory.cpp
+++ b/soh/soh/resource/importer/AudioSoundFontFactory.cpp
@@ -37,20 +37,20 @@ void Ship::AudioSoundFontFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader
     audioSoundFont->medium = reader->ReadInt8();
     audioSoundFont->cachePolicy = reader->ReadInt8();
     
-    audioSoundFont->data1 = reader->ReadUInt16();
+    audioSoundFont->data1 = reader->ReadInt16();
     audioSoundFont->soundFont.sampleBankId1 = audioSoundFont->data1 >> 8;
     audioSoundFont->soundFont.sampleBankId2 = audioSoundFont->data1 & 0xFF;
 
-    audioSoundFont->data2 = reader->ReadUInt16();
-    audioSoundFont->data3 = reader->ReadUInt16();
+    audioSoundFont->data2 = reader->ReadInt16();
+    audioSoundFont->data3 = reader->ReadInt16();
 
-    uint32_t drumCount = reader->ReadUInt32();
+    uint32_t drumCount = reader->ReadInt32();
     audioSoundFont->soundFont.numDrums = drumCount;
     
-    uint32_t instrumentCount = reader->ReadUInt32();
+    uint32_t instrumentCount = reader->ReadInt32();
     audioSoundFont->soundFont.numInstruments = instrumentCount;
     
-    uint32_t soundEffectCount = reader->ReadUInt32();
+    uint32_t soundEffectCount = reader->ReadInt32();
     audioSoundFont->soundFont.numSfx = soundEffectCount;
 
     // 🥁 DRUMS 🥁
@@ -63,7 +63,7 @@ void Ship::AudioSoundFontFactoryV0::ParseFileBinary(std::shared_ptr<BinaryReader
         drum.loaded = reader->ReadUByte();
         drum.loaded = 0; // this was always getting set to zero in ResourceMgr_LoadAudioSoundFont
 
-        uint32_t envelopeCount = reader->ReadUInt32();
+        uint32_t envelopeCount = reader->ReadInt32();
         audioSoundFont->drumEnvelopeCounts.push_back(envelopeCount);
         std::vector<AdsrEnvelope> drumEnvelopes;
         drumEnvelopes.reserve(audioSoundFont->drumEnvelopeCounts[i]);

--- a/soh/src/code/audio_heap.c
+++ b/soh/src/code/audio_heap.c
@@ -808,6 +808,10 @@ void AudioHeap_Init(void) {
     s32 pad2;
     AudioSpec* spec;
 
+    if (gAudioContext.audioResetSpecIdToLoad > 17) {
+        int blarg = 3;
+    }
+
     spec = &gAudioSpecs[gAudioContext.audioResetSpecIdToLoad];
     gAudioContext.sampleDmaCount = 0;
     gAudioContext.audioBufferParameters.frequency = spec->frequency;

--- a/soh/src/code/code_800E4FE0.c
+++ b/soh/src/code/code_800E4FE0.c
@@ -313,6 +313,11 @@ void func_800E5584(AudioCmd* cmd) {
         case 0xF9:
             gAudioContext.resetStatus = 5;
             gAudioContext.audioResetSpecIdToLoad = cmd->asUInt;
+
+            if (gAudioContext.audioResetSpecIdToLoad > 17) {
+                int blarg = 3;
+            }
+
             return;
         case 0xFB:
             D_801755D0 = (void (*)(void))cmd->asUInt;
@@ -499,6 +504,11 @@ void Audio_ProcessCmds(u32 msg) {
             return;
         }
 
+        // it crashes after this
+        if (curCmdRdPos == 3) {
+            int blarg = 3;
+        }
+
         cmd = &gAudioContext.cmdBuf[curCmdRdPos++ & 0xFF];
         if (cmd->op == 0xF8) {
             gAudioContext.cmdQueueFinished = 1;
@@ -563,6 +573,11 @@ s32 func_800E5F88(s32 resetPreloadID) {
             return -2;
         } else if (resetStatus > 2) {
             gAudioContext.audioResetSpecIdToLoad = resetPreloadID;
+
+            if (gAudioContext.audioResetSpecIdToLoad > 17) {
+                int blarg = 3;
+            }
+
             return -3;
         } else {
             osRecvMesg(gAudioContext.audioResetQueueP, &msg, OS_MESG_BLOCK);


### PR DESCRIPTION
added a few
```c
if (gAudioContext.audioResetSpecIdToLoad > 17) {
    int blarg = 3;
}
```
blocks as makeshift conditional breakpoints, this is because of 
https://github.com/briaguya-ai/Shipwright/blob/005d094518ccc931912befaa09de326f6cdda0a6/soh/src/code/audio_heap.c#L815
where `gAudioSpecs` seems to always have only 18 entries

it seems we get in there with some much higher values and it breaks the rest of `AudioHeap_Init` until we end up segfaulting

also tried reverting the signedness of the audio factories to match https://github.com/Kenix3/libultraship/blob/stable/src/resource/types/Audio.cpp, but that didn't seem to make any difference. i figured i'd leave those changes in here as a point of reference as well