### PR TITLE
edit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,5 @@ find soh -name "*.cpp" -or -name "*.hpp" -or -name "*.c" -or -name "*.h" | sed '
 ```
 
 todo: windows
+
+edit

--- a/soh/.clang-format
+++ b/soh/.clang-format
@@ -11,13 +11,8 @@ BinPackArguments: true
 BinPackParameters: true
 AlignAfterOpenBracket: Align
 AlignOperands: true
-AlignConsecutiveDeclarations:
-  Enabled: true
-  AcrossEmptyLines: false
-  AcrossComments: true
-AlignTrailingComments:
-  Kind: Always
-  OverEmptyLines: 1
+AlignConsecutiveDeclarations: ACS_AcrossComments
+AlignTrailingComments: true
 BreakBeforeTernaryOperators: true
 BreakBeforeBinaryOperators: None
 AllowShortBlocksOnASingleLine: true

--- a/soh/.clang-format
+++ b/soh/.clang-format
@@ -11,7 +11,7 @@ BinPackArguments: true
 BinPackParameters: true
 AlignAfterOpenBracket: Align
 AlignOperands: true
-AlignConsecutiveDeclarations: ACS_AcrossComments
+AlignConsecutiveDeclarations: AcrossComments
 AlignTrailingComments: true
 BreakBeforeTernaryOperators: true
 BreakBeforeBinaryOperators: None


### PR DESCRIPTION
thanks for making a PR

we have `clang-format-14` as part of the CI process, to make sure your code passes `clang-format` validation you can run

```sh
find soh -name "*.cpp" -or -name "*.hpp" -or -name "*.c" -or -name "*.h" | sed 's| |\\ |g' | xargs clang-format-14 -i
```

todo: windows